### PR TITLE
Enable undoing `view` command with `list` command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/ListCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ListCommand.java
@@ -19,6 +19,7 @@ public class ListCommand extends Command {
     public CommandResult execute(Model model) {
         requireNonNull(model);
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
+        model.getSelectedPerson().setValue(null);
         return new CommandResult(MESSAGE_SUCCESS);
     }
 }

--- a/src/main/java/seedu/address/ui/ContentDisplay.java
+++ b/src/main/java/seedu/address/ui/ContentDisplay.java
@@ -42,8 +42,13 @@ public class ContentDisplay extends UiPart<Region> {
         });
 
         selectedPerson.addListener((observable, oldValue, newValue) -> {
-            clientProfilePanel = new ClientProfilePanel(newValue);
             clientProfilePanelPlaceholder.getChildren().clear();
+
+            if (newValue == null) {
+                return;
+            }
+
+            clientProfilePanel = new ClientProfilePanel(newValue);
             clientProfilePanelPlaceholder.getChildren().add(clientProfilePanel.getRoot());
 
             // set focus within the list if the change is from a `view` command

--- a/src/main/resources/view/PersonListCard.fxml
+++ b/src/main/resources/view/PersonListCard.fxml
@@ -22,9 +22,12 @@
           </minWidth>
         </Label>
         <Label fx:id="name" styleClass="cell_big_label" text="\$first">
-               <HBox.margin>
-                  <Insets />
-               </HBox.margin>
+          <minWidth>
+            <Region fx:constant="USE_PREF_SIZE" />
+          </minWidth>
+           <HBox.margin>
+              <Insets />
+           </HBox.margin>
         </Label>
         <FlowPane fx:id="lead" />
       </HBox>


### PR DESCRIPTION
Fixes #73.

Entering the `list` command will now hide the client profile panel.

Also fixes the issue of names being truncated after the profile panel appears.

<img width="954" alt="image" src="https://github.com/AY2324S1-CS2103T-F11-4/tp/assets/25928055/d5ece6d7-a078-4e36-84f4-4ea765e4b114">
