### PR TITLE
Ported Dashboard Logic

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DashboardCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DashboardCommand.java
@@ -2,12 +2,9 @@ package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
 
-import javafx.collections.ObservableList;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Dashboard;
 import seedu.address.model.Model;
-import seedu.address.model.person.Person;
-import seedu.address.model.person.interaction.Interaction;
 
 /**
  * Shows the dashboard containing statistics of the address book.
@@ -43,18 +40,5 @@ public class DashboardCommand extends Command {
                 + String.format("%.2f", notInterestedPercentage) + "%\n";
 
         return new CommandResult(MESSAGE_SUCCESS + "\n" + message);
-    }
-
-    private int getSpecifiedOutcomeCount(ObservableList<Person> personList, Interaction.Outcome outcome) {
-        return personList.stream()
-                .map(person ->
-                        person.getFilteredInteractions(i -> i.isOutcome(outcome)).size())
-                .reduce(0, Integer::sum);
-    }
-
-    private int getInteractionCount(ObservableList<Person> personList) {
-        return personList.stream()
-                .mapToInt(person -> person.getInteractions().size())
-                .sum();
     }
 }

--- a/src/main/java/seedu/address/logic/commands/DashboardCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DashboardCommand.java
@@ -4,8 +4,8 @@ import static java.util.Objects.requireNonNull;
 
 import javafx.collections.ObservableList;
 import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Dashboard;
 import seedu.address.model.Model;
-import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.interaction.Interaction;
 
@@ -20,20 +20,19 @@ public class DashboardCommand extends Command {
 
     public static final String MESSAGE_SUCCESS = "DASHBOARD";
 
+    /**
+     * Opens the dashboard for viewing.
+     */
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        ReadOnlyAddressBook addressBook = model.getAddressBook();
-        ObservableList<Person> personList = addressBook.getPersonList();
+        Dashboard dashboard = model.getDashboard();
+        dashboard.openDashboard();
 
-        int interactionCount = getInteractionCount(personList);
+        int interactionCount = dashboard.getTotalInteraction();
 
-        int interestedInteractionsCount = getSpecifiedOutcomeCount(personList, Interaction.Outcome.INTERESTED);
-
-        int notInterestedInteractionsCount = getSpecifiedOutcomeCount(personList, Interaction.Outcome.NOT_INTERESTED);
-
-        double interestedPercentage = (double) interestedInteractionsCount / interactionCount * 100;
-        double notInterestedPercentage = (double) notInterestedInteractionsCount / interactionCount * 100;
+        double interestedPercentage = dashboard.interestedPercentage();
+        double notInterestedPercentage = dashboard.notInterestedPercentage();
 
         // Might want to refactor this for flexibility. Left as is for now.
         String message = "Total number of interactions: "

--- a/src/main/java/seedu/address/model/Dashboard.java
+++ b/src/main/java/seedu/address/model/Dashboard.java
@@ -55,6 +55,7 @@ public class Dashboard {
 
     /**
      * Returns the updated dashboard and opens the dashboard for viewing.
+     * The dashboard should always be closed after viewing as updating the dashboard may be expensive.
      */
     public Dashboard openDashboard() {
         updateDashboardIfDirty();

--- a/src/main/java/seedu/address/model/Dashboard.java
+++ b/src/main/java/seedu/address/model/Dashboard.java
@@ -1,0 +1,7 @@
+package seedu.address.model;
+
+/**
+ * Represents the dashboard of the address book.
+ */
+public class Dashboard {
+}

--- a/src/main/java/seedu/address/model/Dashboard.java
+++ b/src/main/java/seedu/address/model/Dashboard.java
@@ -1,10 +1,10 @@
 package seedu.address.model;
 
+import static java.util.Objects.requireNonNull;
+
 import javafx.collections.ObservableList;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.interaction.Interaction;
-
-import static java.util.Objects.requireNonNull;
 
 /**
  * Represents the dashboard of the address book.
@@ -21,6 +21,9 @@ public class Dashboard {
     private int totalInterestedInteractions;
     private int totalNotInterestedInteractions;
 
+    /**
+     * Constructs a {@code Dashboard} with the given {@code Model}.
+     */
     public Dashboard(Model model) {
         requireNonNull(model);
         this.model = model;
@@ -60,6 +63,9 @@ public class Dashboard {
         return this;
     }
 
+    /**
+     * Closes the dashboard.
+     */
     public Dashboard closeDashboard() {
         this.isDashboardOpen = false;
         return this;

--- a/src/main/java/seedu/address/model/Dashboard.java
+++ b/src/main/java/seedu/address/model/Dashboard.java
@@ -1,7 +1,122 @@
 package seedu.address.model;
 
+import javafx.collections.ObservableList;
+import seedu.address.model.person.Person;
+import seedu.address.model.person.interaction.Interaction;
+
+import static java.util.Objects.requireNonNull;
+
 /**
  * Represents the dashboard of the address book.
  */
 public class Dashboard {
+    private final Model model;
+
+    private boolean isDashboardDirty = true;
+    private boolean isDashboardOpen = false;
+
+    // ============ Dashboard Data Fields ===================================
+    // These fields may be grouped into a DashboardData class in the future.
+    private int totalInteraction;
+    private int totalInterestedInteractions;
+    private int totalNotInterestedInteractions;
+
+    public Dashboard(Model model) {
+        requireNonNull(model);
+        this.model = model;
+    }
+
+    /**
+     * Returns the total number of interactions in the address book.
+     */
+    public int getTotalInteraction() {
+        updateDashboardIfDirty();
+        return totalInteraction;
+    }
+
+    /**
+     * Returns the percentage of interactions with outcome INTERESTED.
+     */
+    public double interestedPercentage() {
+        updateDashboardIfDirty();
+        return (double) totalInterestedInteractions / totalInteraction * 100;
+    }
+
+    /**
+     * Returns the percentage of interactions with outcome NOT_INTERESTED.
+     */
+    public double notInterestedPercentage() {
+        updateDashboardIfDirty();
+        return (double) totalNotInterestedInteractions / totalInteraction * 100;
+    }
+
+    /**
+     * Returns the updated dashboard and opens the dashboard for viewing.
+     */
+    public Dashboard openDashboard() {
+        updateDashboardIfDirty();
+
+        this.isDashboardOpen = true;
+        return this;
+    }
+
+    public Dashboard closeDashboard() {
+        this.isDashboardOpen = false;
+        return this;
+    }
+
+    public boolean isDashboardOpen() {
+        return this.isDashboardOpen;
+    }
+
+    /**
+     * Sets the dashboard to be dirty.
+     * To be called when data related to the dashboard is changed.
+     */
+    public void setDashboardDirty() {
+        this.isDashboardDirty = true;
+    }
+
+    private void updateDashboardIfDirty() {
+        if (!isDashboardDirty) {
+            return;
+        }
+
+        totalInteraction = countPersonListInteraction();
+        totalInterestedInteractions = countPersonListWithSpecifiedOutcome(Interaction.Outcome.INTERESTED);
+        totalNotInterestedInteractions = countPersonListWithSpecifiedOutcome(Interaction.Outcome.NOT_INTERESTED);
+
+        /*
+         Set dashboard to be clean below. Not written yet as there is no overarching mechanism to integrate
+         the dashboard logic with the rest of the code.
+        */
+    }
+
+    private int countPersonListWithSpecifiedOutcome(Interaction.Outcome outcome) {
+        ObservableList<Person> personList = model.getAddressBook().getPersonList();
+
+        return personList.stream()
+                .map(person ->
+                        person.getFilteredInteractions(i -> i.isOutcome(outcome)).size())
+                .reduce(0, Integer::sum);
+    }
+
+    private int countPersonListInteraction() {
+        ObservableList<Person> personList = model.getAddressBook().getPersonList();
+
+        return personList.stream()
+                .mapToInt(person -> person.getInteractions().size())
+                .sum();
+    }
+
+    /**
+     * Two dashboards are equal if and only if they have the same model.
+     */
+    @Override
+    public boolean equals(Object other) {
+        return other == this // short circuit if same object
+                || (other instanceof Dashboard // instanceof handles nulls
+                && model.equals(((Dashboard) other).model));
+    }
+
 }

--- a/src/main/java/seedu/address/model/Model.java
+++ b/src/main/java/seedu/address/model/Model.java
@@ -54,6 +54,11 @@ public interface Model {
     ReadOnlyAddressBook getAddressBook();
 
     /**
+     * Returns the Dashboard
+     */
+    Dashboard getDashboard();
+
+    /**
      * Returns true if a person with the same identity as {@code person} exists in the address book.
      */
     boolean hasPerson(Person person);

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -24,7 +24,7 @@ public class ModelManager implements Model {
     private final UserPrefs userPrefs;
     private final FilteredList<Person> filteredPersons;
     private final SimpleObjectProperty<Person> selectedPerson = new SimpleObjectProperty<>();
-    private final Dashboard dashboard = new Dashboard();
+    private final Dashboard dashboard = new Dashboard(this);
 
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -24,6 +24,7 @@ public class ModelManager implements Model {
     private final UserPrefs userPrefs;
     private final FilteredList<Person> filteredPersons;
     private final SimpleObjectProperty<Person> selectedPerson = new SimpleObjectProperty<>();
+    private final Dashboard dashboard = new Dashboard();
 
     /**
      * Initializes a ModelManager with the given addressBook and userPrefs.
@@ -111,6 +112,12 @@ public class ModelManager implements Model {
         requireAllNonNull(target, editedPerson);
 
         addressBook.setPerson(target, editedPerson);
+    }
+
+    //=========== Dashboard ================================
+    @Override
+    public Dashboard getDashboard() {
+        return dashboard;
     }
 
     //=========== Filtered Person List Accessors =============================================================

--- a/src/test/java/seedu/address/logic/commands/CreateCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/CreateCommandTest.java
@@ -20,6 +20,7 @@ import seedu.address.commons.core.GuiSettings;
 import seedu.address.logic.Messages;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.AddressBook;
+import seedu.address.model.Dashboard;
 import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.ReadOnlyUserPrefs;
@@ -147,6 +148,11 @@ public class CreateCommandTest {
 
         @Override
         public void setPerson(Person target, Person editedPerson) {
+            throw new AssertionError("This method should not be called.");
+        }
+
+        @Override
+        public Dashboard getDashboard() {
             throw new AssertionError("This method should not be called.");
         }
 


### PR DESCRIPTION
This PR contains changes to encapsulate `Dashboard` as one of the entities that composes `Model`. The DG will be updated later to contain the following information:

- Dashboard contains (or will contain) operations that are expensive to carry out.
- It is not nice to execute such operation for every small data update in the `Model` (or `AddressBook`), but we have to do it anyway since even small change in data affects the dashboard.
- Observing that dashboard is not always displayed, we can thus delay operations pertaining to data in the `Dashboard` for as long as the `Dashboard` is not open (or when the data is not used).
- I implement this by setting a dirty flag that is now currently always set to true (meaning operations will always be carried out without delay). The reason for always setting it to true is that there is no overarching structure that can automatically flags the Dashboard to be dirty without interfering with other features as of right now.
- It is recommended that the Dashboard should always be closed after it is no longer viewed.

Might be relevant to how interaction features from @MagnificentCreature are implemented. 
@zhyuhan Let me know if need more stats or any change in general.
@lilozz2 Idk if this is relevant to your part (esp. the parts related to the dirty flag) so imma just tag 