### PR TITLE
Dashboard view

### DIFF
--- a/src/main/java/seedu/address/logic/Logic.java
+++ b/src/main/java/seedu/address/logic/Logic.java
@@ -8,6 +8,7 @@ import seedu.address.commons.core.GuiSettings;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.Dashboard;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.person.Person;
 
@@ -30,6 +31,13 @@ public interface Logic {
      * @see seedu.address.model.Model#getAddressBook()
      */
     ReadOnlyAddressBook getAddressBook();
+
+    /**
+     * Returns the Dashboard.
+     *
+     * @see seedu.address.model.Model#getDashboard()
+     */
+    Dashboard getDashboard();
 
     /** Returns an unmodifiable view of the filtered list of persons */
     ObservableList<Person> getFilteredPersonList();

--- a/src/main/java/seedu/address/logic/LogicManager.java
+++ b/src/main/java/seedu/address/logic/LogicManager.java
@@ -14,6 +14,7 @@ import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.AddressBookParser;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.Dashboard;
 import seedu.address.model.Model;
 import seedu.address.model.ReadOnlyAddressBook;
 import seedu.address.model.person.Person;
@@ -65,6 +66,11 @@ public class LogicManager implements Logic {
     @Override
     public ReadOnlyAddressBook getAddressBook() {
         return model.getAddressBook();
+    }
+
+    @Override
+    public Dashboard getDashboard() {
+        return model.getDashboard();
     }
 
     @Override

--- a/src/main/java/seedu/address/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/CommandResult.java
@@ -74,7 +74,8 @@ public class CommandResult {
         }
 
         CommandResult otherCommandResult = (CommandResult) other;
-        return feedbackToUser.equals(otherCommandResult.feedbackToUser) && showHelp == otherCommandResult.showHelp && exit == otherCommandResult.exit;
+        return feedbackToUser.equals(otherCommandResult.feedbackToUser) && showHelp == otherCommandResult.showHelp
+                && exit == otherCommandResult.exit;
     }
 
     @Override
@@ -84,7 +85,10 @@ public class CommandResult {
 
     @Override
     public String toString() {
-        return new ToStringBuilder(this).add("feedbackToUser", feedbackToUser).add("showHelp", showHelp).add("exit", exit).toString();
+        return new ToStringBuilder(this).add("feedbackToUser", feedbackToUser)
+                                        .add("showHelp", showHelp)
+                                        .add("exit", exit)
+                                        .toString();
     }
 
 }

--- a/src/main/java/seedu/address/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/CommandResult.java
@@ -13,17 +13,27 @@ public class CommandResult {
 
     private final String feedbackToUser;
 
-    /** Help information should be shown to the user. */
+    /**
+     * Dashboard should be shown to the user.
+     */
+    private final boolean showDashboard;
+
+    /**
+     * Help information should be shown to the user.
+     */
     private final boolean showHelp;
 
-    /** The application should exit. */
+    /**
+     * The application should exit.
+     */
     private final boolean exit;
 
     /**
      * Constructs a {@code CommandResult} with the specified fields.
      */
-    public CommandResult(String feedbackToUser, boolean showHelp, boolean exit) {
+    public CommandResult(String feedbackToUser, boolean showDashboard, boolean showHelp, boolean exit) {
         this.feedbackToUser = requireNonNull(feedbackToUser);
+        this.showDashboard = showDashboard;
         this.showHelp = showHelp;
         this.exit = exit;
     }
@@ -33,11 +43,15 @@ public class CommandResult {
      * and other fields set to their default value.
      */
     public CommandResult(String feedbackToUser) {
-        this(feedbackToUser, false, false);
+        this(feedbackToUser, false, false, false);
     }
 
     public String getFeedbackToUser() {
         return feedbackToUser;
+    }
+
+    public boolean isShowDashboard() {
+        return showDashboard;
     }
 
     public boolean isShowHelp() {
@@ -60,9 +74,7 @@ public class CommandResult {
         }
 
         CommandResult otherCommandResult = (CommandResult) other;
-        return feedbackToUser.equals(otherCommandResult.feedbackToUser)
-                && showHelp == otherCommandResult.showHelp
-                && exit == otherCommandResult.exit;
+        return feedbackToUser.equals(otherCommandResult.feedbackToUser) && showHelp == otherCommandResult.showHelp && exit == otherCommandResult.exit;
     }
 
     @Override
@@ -72,11 +84,7 @@ public class CommandResult {
 
     @Override
     public String toString() {
-        return new ToStringBuilder(this)
-                .add("feedbackToUser", feedbackToUser)
-                .add("showHelp", showHelp)
-                .add("exit", exit)
-                .toString();
+        return new ToStringBuilder(this).add("feedbackToUser", feedbackToUser).add("showHelp", showHelp).add("exit", exit).toString();
     }
 
 }

--- a/src/main/java/seedu/address/logic/commands/CommandResult.java
+++ b/src/main/java/seedu/address/logic/commands/CommandResult.java
@@ -74,21 +74,23 @@ public class CommandResult {
         }
 
         CommandResult otherCommandResult = (CommandResult) other;
-        return feedbackToUser.equals(otherCommandResult.feedbackToUser) && showHelp == otherCommandResult.showHelp
+        return feedbackToUser.equals(otherCommandResult.feedbackToUser)
+                && showDashboard == otherCommandResult.showDashboard && showHelp == otherCommandResult.showHelp
                 && exit == otherCommandResult.exit;
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(feedbackToUser, showHelp, exit);
+        return Objects.hash(feedbackToUser, showDashboard, showHelp, exit);
     }
 
     @Override
     public String toString() {
         return new ToStringBuilder(this).add("feedbackToUser", feedbackToUser)
-                                        .add("showHelp", showHelp)
-                                        .add("exit", exit)
-                                        .toString();
+                .add("showDashboard", showDashboard)
+                .add("showHelp", showHelp)
+                .add("exit", exit)
+                .toString();
     }
 
 }

--- a/src/main/java/seedu/address/logic/commands/DashboardCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DashboardCommand.java
@@ -15,30 +15,13 @@ public class DashboardCommand extends Command {
 
     public static final String MESSAGE_USAGE = COMMAND_WORD + ": Shows the dashboard. ";
 
-    public static final String MESSAGE_SUCCESS = "DASHBOARD";
+    public static final String SHOWING_DASHBOARD_MESSAGE = "Showing dashboard";
 
     /**
      * Opens the dashboard for viewing.
      */
     @Override
     public CommandResult execute(Model model) throws CommandException {
-        requireNonNull(model);
-        Dashboard dashboard = model.getDashboard();
-        dashboard.openDashboard();
-
-        int interactionCount = dashboard.getTotalInteraction();
-
-        double interestedPercentage = dashboard.interestedPercentage();
-        double notInterestedPercentage = dashboard.notInterestedPercentage();
-
-        // Might want to refactor this for flexibility. Left as is for now.
-        String message = "Total number of interactions: "
-                + interactionCount + "\n"
-                + "Percentage of interested interactions: "
-                + String.format("%.2f", interestedPercentage) + "%\n"
-                + "Percentage of not interested interactions: "
-                + String.format("%.2f", notInterestedPercentage) + "%\n";
-
-        return new CommandResult(MESSAGE_SUCCESS + "\n" + message);
+        return new CommandResult(SHOWING_DASHBOARD_MESSAGE, true, false, false);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/DashboardCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DashboardCommand.java
@@ -1,9 +1,6 @@
 package seedu.address.logic.commands;
 
-import static java.util.Objects.requireNonNull;
-
 import seedu.address.logic.commands.exceptions.CommandException;
-import seedu.address.model.Dashboard;
 import seedu.address.model.Model;
 
 /**

--- a/src/main/java/seedu/address/logic/commands/ExitCommand.java
+++ b/src/main/java/seedu/address/logic/commands/ExitCommand.java
@@ -13,7 +13,7 @@ public class ExitCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) {
-        return new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, true);
+        return new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, false, true);
     }
 
 }

--- a/src/main/java/seedu/address/logic/commands/HelpCommand.java
+++ b/src/main/java/seedu/address/logic/commands/HelpCommand.java
@@ -16,6 +16,6 @@ public class HelpCommand extends Command {
 
     @Override
     public CommandResult execute(Model model) {
-        return new CommandResult(SHOWING_HELP_MESSAGE, true, false);
+        return new CommandResult(SHOWING_HELP_MESSAGE, false, true, false);
     }
 }

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -117,6 +117,48 @@ public class Person {
     }
 
     /**
+     * Returns true if the person has not been contacted yet, i.e. no interactions.
+     */
+    public boolean isUncontacted() {
+        return this.interactions.isEmpty();
+    }
+
+    /**
+     * Returns true if the person has a closed interaction.
+     */
+    public boolean isClosed() {
+        return this.interactions.stream().anyMatch(i -> i.isOutcome(Interaction.Outcome.CLOSED));
+    }
+
+    /**
+     * Returns true if the person is still in contact.
+     */
+    public boolean isContacting() {
+        return !isUncontacted() && !isClosed();
+    }
+
+    /**
+     * Returns true if the person is a hot lead.
+     */
+    public boolean isHotLead() {
+        return this.lead.isHot();
+    }
+
+    /**
+     * Returns true if the person is a warm lead.
+     */
+    public boolean isWarmLead() {
+        return this.lead.isWarm();
+    }
+
+    /**
+     * Returns true if the person is a cold lead.
+     */
+    public boolean isColdLead() {
+        return this.lead.isCold();
+    }
+
+    /**
      * Adds an interaction to the person.
      * @param interactions the set of interaction to be added
      * @return the updated set of interactions

--- a/src/main/java/seedu/address/model/person/lead/Lead.java
+++ b/src/main/java/seedu/address/model/person/lead/Lead.java
@@ -34,6 +34,7 @@ public class Lead {
         return lead.equalsIgnoreCase("HOT")
                 || lead.equalsIgnoreCase("WARM")
                 || lead.equalsIgnoreCase("COLD");
+    }
 
     /**
      * Returns true if the lead is hot.

--- a/src/main/java/seedu/address/model/person/lead/Lead.java
+++ b/src/main/java/seedu/address/model/person/lead/Lead.java
@@ -34,6 +34,26 @@ public class Lead {
         return lead.equalsIgnoreCase("HOT")
                 || lead.equalsIgnoreCase("WARM")
                 || lead.equalsIgnoreCase("COLD");
+
+    /**
+     * Returns true if the lead is hot.
+     */
+    public boolean isHot() {
+        return leadType.equals(LeadType.HOT);
+    }
+
+    /**
+     * Returns true if the lead is warm.
+     */
+    public boolean isWarm() {
+        return leadType.equals(LeadType.WARM);
+    }
+
+    /**
+     * Returns true if the lead is cold.
+     */
+    public boolean isCold() {
+        return leadType.equals(LeadType.COLD);
     }
 
     @Override

--- a/src/main/java/seedu/address/ui/ClientDisplay.java
+++ b/src/main/java/seedu/address/ui/ClientDisplay.java
@@ -8,7 +8,6 @@ import javafx.fxml.FXML;
 import javafx.scene.control.ListCell;
 import javafx.scene.control.ListView;
 import javafx.scene.layout.Region;
-import javafx.scene.layout.StackPane;
 import javafx.scene.layout.VBox;
 import seedu.address.commons.core.LogsCenter;
 import seedu.address.model.person.Person;
@@ -16,23 +15,21 @@ import seedu.address.model.person.Person;
 /**
  * The area for displaying content.
  */
-public class ContentDisplay extends UiPart<Region> {
-    private static final String FXML = "ContentDisplay.fxml";
-    private final Logger logger = LogsCenter.getLogger(ContentDisplay.class);
+public class ClientDisplay extends UiPart<Region> {
+    private static final String FXML = "ClientDisplay.fxml";
+    private final Logger logger = LogsCenter.getLogger(ClientDisplay.class);
 
     private ClientProfilePanel clientProfilePanel;
 
     @FXML
     private ListView<Person> personListView;
     @FXML
-    private StackPane contentDisplayPlaceholder;
-    @FXML
     private VBox clientProfilePanelPlaceholder;
 
     /**
-     * Creates a {@code ContentDisplay} with the given {@code personList} and {@code selectedPerson}.
+     * Creates a {@code ClientDisplay} with the given {@code personList} and {@code selectedPerson}.
      */
-    public ContentDisplay(ObservableList<Person> personList, SimpleObjectProperty<Person> selectedPerson) {
+    public ClientDisplay(ObservableList<Person> personList, SimpleObjectProperty<Person> selectedPerson) {
         super(FXML);
 
         personListView.setItems(personList);
@@ -41,19 +38,28 @@ public class ContentDisplay extends UiPart<Region> {
             selectedPerson.setValue(newValue);
         });
 
+        viewPerson(selectedPerson.getValue());
+
         selectedPerson.addListener((observable, oldValue, newValue) -> {
             clientProfilePanelPlaceholder.getChildren().clear();
 
-            if (newValue == null) {
-                return;
-            }
-
-            clientProfilePanel = new ClientProfilePanel(newValue);
-            clientProfilePanelPlaceholder.getChildren().add(clientProfilePanel.getRoot());
-
-            // set focus within the list if the change is from a `view` command
-            personListView.getSelectionModel().select(newValue);
+            viewPerson(newValue);
         });
+    }
+
+    /**
+     * Displays the profile of the given {@code person}.
+     */
+    void viewPerson(Person person) {
+        if (person == null) {
+            return;
+        }
+
+        clientProfilePanel = new ClientProfilePanel(person);
+        clientProfilePanelPlaceholder.getChildren().add(clientProfilePanel.getRoot());
+
+        // set focus within the list if the change is from a `view` command
+        personListView.getSelectionModel().select(person);
     }
 
     /**

--- a/src/main/java/seedu/address/ui/DashboardDisplay.java
+++ b/src/main/java/seedu/address/ui/DashboardDisplay.java
@@ -1,0 +1,32 @@
+package seedu.address.ui;
+
+import javafx.collections.FXCollections;
+import javafx.collections.ObservableList;
+import javafx.fxml.FXML;
+import javafx.scene.chart.PieChart;
+import javafx.scene.layout.Region;
+import seedu.address.model.Dashboard;
+
+public class DashboardDisplay extends UiPart<Region> {
+    private static final String FXML = "DashboardDisplay.fxml";
+
+    @FXML
+    PieChart pieChart;
+
+    /**
+     * Creates a {@code DashboardDisplay} using data from the given {@code dashboard}.
+     */
+    public DashboardDisplay(Dashboard dashboard) {
+        super(FXML);
+
+        double interested = dashboard.interestedPercentage();
+        double notInterested = dashboard.notInterestedPercentage();
+
+        ObservableList<PieChart.Data> data = FXCollections.observableArrayList(
+                new PieChart.Data("Interested", interested),
+                new PieChart.Data("Not Interested", notInterested)
+        );
+
+        pieChart.setData(data);
+    }
+}

--- a/src/main/java/seedu/address/ui/DashboardDisplay.java
+++ b/src/main/java/seedu/address/ui/DashboardDisplay.java
@@ -7,11 +7,14 @@ import javafx.scene.chart.PieChart;
 import javafx.scene.layout.Region;
 import seedu.address.model.Dashboard;
 
+/**
+ * The Dashboard Display.
+ */
 public class DashboardDisplay extends UiPart<Region> {
     private static final String FXML = "DashboardDisplay.fxml";
 
     @FXML
-    PieChart pieChart;
+    private PieChart pieChart;
 
     /**
      * Creates a {@code DashboardDisplay} using data from the given {@code dashboard}.
@@ -23,9 +26,7 @@ public class DashboardDisplay extends UiPart<Region> {
         double notInterested = dashboard.notInterestedPercentage();
 
         ObservableList<PieChart.Data> data = FXCollections.observableArrayList(
-                new PieChart.Data("Interested", interested),
-                new PieChart.Data("Not Interested", notInterested)
-        );
+                new PieChart.Data("Interested", interested), new PieChart.Data("Not Interested", notInterested));
 
         pieChart.setData(data);
     }

--- a/src/main/java/seedu/address/ui/DashboardDisplay.java
+++ b/src/main/java/seedu/address/ui/DashboardDisplay.java
@@ -3,9 +3,15 @@ package seedu.address.ui;
 import javafx.collections.FXCollections;
 import javafx.collections.ObservableList;
 import javafx.fxml.FXML;
+import javafx.scene.chart.BarChart;
+import javafx.scene.chart.CategoryAxis;
+import javafx.scene.chart.NumberAxis;
 import javafx.scene.chart.PieChart;
+import javafx.scene.chart.XYChart;
+import javafx.scene.control.Label;
 import javafx.scene.layout.Region;
 import seedu.address.model.Dashboard;
+import seedu.address.model.person.lead.LeadType;
 
 /**
  * The Dashboard Display.
@@ -14,7 +20,21 @@ public class DashboardDisplay extends UiPart<Region> {
     private static final String FXML = "DashboardDisplay.fxml";
 
     @FXML
+    private Label interactionsPerClient;
+    @FXML
+    private Label uncontacted;
+    @FXML
+    private Label contacting;
+    @FXML
+    private Label closed;
+    @FXML
     private PieChart pieChart;
+    @FXML
+    private BarChart<String, Integer> barChart;
+    @FXML
+    private CategoryAxis xAxis;
+    @FXML
+    private NumberAxis yAxis;
 
     /**
      * Creates a {@code DashboardDisplay} using data from the given {@code dashboard}.
@@ -22,12 +42,46 @@ public class DashboardDisplay extends UiPart<Region> {
     public DashboardDisplay(Dashboard dashboard) {
         super(FXML);
 
+        // stats
+        interactionsPerClient.setText(String.valueOf(dashboard.averageInteractionsPerClient()));
+        uncontacted.setText(String.valueOf(dashboard.getNumUncontactedClients()));
+        contacting.setText(String.valueOf(dashboard.getNumContactingClients()));
+        closed.setText(String.valueOf(dashboard.getNumClosedClients()));
+
+        // pie chart
+        double closed = dashboard.closedPercentage();
         double interested = dashboard.interestedPercentage();
         double notInterested = dashboard.notInterestedPercentage();
+        double followUpRequired = dashboard.followUpRequiredPercentage();
+        double unknown = dashboard.unknownPercentage();
 
         ObservableList<PieChart.Data> data = FXCollections.observableArrayList(
-                new PieChart.Data("Interested", interested), new PieChart.Data("Not Interested", notInterested));
+                new PieChart.Data("Interested", interested), new PieChart.Data("Not Interested", notInterested),
+                new PieChart.Data("Follow Up Required", followUpRequired), new PieChart.Data("Closed", closed),
+                new PieChart.Data("Unknown", unknown));
 
         pieChart.setData(data);
+
+        // bar chart
+        int totalHotLeads = dashboard.getTotalHotLeads();
+        int totalWarmLeads = dashboard.getTotalWarmLeads();
+        int totalColdLeads = dashboard.getTotalColdLeads();
+
+        XYChart.Series<String, Integer> series = new XYChart.Series<>();
+        series.getData().add(new XYChart.Data<>(LeadType.HOT.toString(), totalHotLeads));
+        series.getData().add(new XYChart.Data<>(LeadType.WARM.toString(), totalWarmLeads));
+        series.getData().add(new XYChart.Data<>(LeadType.COLD.toString(), totalColdLeads));
+
+        barChart.getData().add(series);
+
+        // set axis
+        double maxY = Math.ceil(1.25 * Math.max(totalHotLeads, Math.max(totalWarmLeads, totalColdLeads)));
+
+        xAxis.setLabel("Leads");
+        yAxis.setLabel("Number of clients");
+        yAxis.setMinorTickVisible(false);
+        yAxis.setTickUnit(1);
+        yAxis.setAutoRanging(false);
+        yAxis.setUpperBound(maxY);
     }
 }

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -16,6 +16,7 @@ import seedu.address.logic.Logic;
 import seedu.address.logic.commands.CommandResult;
 import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.parser.exceptions.ParseException;
+import seedu.address.model.Dashboard;
 
 /**
  * The Main Window. Provides the basic application layout containing
@@ -31,7 +32,6 @@ public class MainWindow extends UiPart<Stage> {
     private Logic logic;
 
     // Independent Ui parts residing in this Ui container
-    private ContentDisplay contentDisplay;
     private ResultDisplay resultDisplay;
     private HelpWindow helpWindow;
 
@@ -42,10 +42,10 @@ public class MainWindow extends UiPart<Stage> {
     private MenuItem helpMenuItem;
 
     @FXML
-    private StackPane contentDisplayPlaceholder;
+    private StackPane resultDisplayPlaceholder;
 
     @FXML
-    private StackPane resultDisplayPlaceholder;
+    private StackPane content;
 
     @FXML
     private StackPane statusbarPlaceholder;
@@ -78,6 +78,7 @@ public class MainWindow extends UiPart<Stage> {
 
     /**
      * Sets the accelerator of a MenuItem.
+     *
      * @param keyCombination the KeyCombination value of the accelerator
      */
     private void setAccelerator(MenuItem menuItem, KeyCombination keyCombination) {
@@ -110,8 +111,8 @@ public class MainWindow extends UiPart<Stage> {
      * Fills up all the placeholders of this window.
      */
     void fillInnerParts() {
-        contentDisplay = new ContentDisplay(logic.getFilteredPersonList(), logic.getSelectedPerson());
-        contentDisplayPlaceholder.getChildren().add(contentDisplay.getRoot());
+        // show dashboard by default
+        fillContent(true);
 
         resultDisplay = new ResultDisplay();
         resultDisplayPlaceholder.getChildren().add(resultDisplay.getRoot());
@@ -136,6 +137,22 @@ public class MainWindow extends UiPart<Stage> {
     }
 
     /**
+     * Handles the toggling of display between dashboard and client info.
+     */
+    public void fillContent(boolean showDashboard) {
+        content.getChildren().clear();
+
+        Dashboard dashboard = logic.getDashboard();
+        if (showDashboard) {
+            dashboard.openDashboard();
+            content.getChildren().add(new DashboardDisplay(dashboard).getRoot());
+        } else {
+            dashboard.closeDashboard();
+            content.getChildren().add(new ClientDisplay(logic.getFilteredPersonList(), logic.getSelectedPerson()).getRoot());
+        }
+    }
+
+    /**
      * Opens the help window or focuses on it if it's already opened.
      */
     @FXML
@@ -156,8 +173,7 @@ public class MainWindow extends UiPart<Stage> {
      */
     @FXML
     private void handleExit() {
-        GuiSettings guiSettings = new GuiSettings(primaryStage.getWidth(), primaryStage.getHeight(),
-                (int) primaryStage.getX(), (int) primaryStage.getY());
+        GuiSettings guiSettings = new GuiSettings(primaryStage.getWidth(), primaryStage.getHeight(), (int) primaryStage.getX(), (int) primaryStage.getY());
         logic.setGuiSettings(guiSettings);
         helpWindow.hide();
         primaryStage.hide();
@@ -173,6 +189,8 @@ public class MainWindow extends UiPart<Stage> {
             CommandResult commandResult = logic.execute(commandText);
             logger.info("Result: " + commandResult.getFeedbackToUser());
             resultDisplay.setFeedbackToUser(commandResult.getFeedbackToUser());
+
+            fillContent(commandResult.isShowDashboard());
 
             if (commandResult.isShowHelp()) {
                 handleHelp();

--- a/src/main/java/seedu/address/ui/MainWindow.java
+++ b/src/main/java/seedu/address/ui/MainWindow.java
@@ -148,7 +148,8 @@ public class MainWindow extends UiPart<Stage> {
             content.getChildren().add(new DashboardDisplay(dashboard).getRoot());
         } else {
             dashboard.closeDashboard();
-            content.getChildren().add(new ClientDisplay(logic.getFilteredPersonList(), logic.getSelectedPerson()).getRoot());
+            content.getChildren()
+                   .add(new ClientDisplay(logic.getFilteredPersonList(), logic.getSelectedPerson()).getRoot());
         }
     }
 
@@ -173,7 +174,8 @@ public class MainWindow extends UiPart<Stage> {
      */
     @FXML
     private void handleExit() {
-        GuiSettings guiSettings = new GuiSettings(primaryStage.getWidth(), primaryStage.getHeight(), (int) primaryStage.getX(), (int) primaryStage.getY());
+        GuiSettings guiSettings = new GuiSettings(primaryStage.getWidth(), primaryStage.getHeight(),
+                                                  (int) primaryStage.getX(), (int) primaryStage.getY());
         logic.setGuiSettings(guiSettings);
         helpWindow.hide();
         primaryStage.hide();

--- a/src/main/resources/view/ClientDisplay.fxml
+++ b/src/main/resources/view/ClientDisplay.fxml
@@ -13,7 +13,5 @@
         <ListView fx:id="personListView" VBox.vgrow="ALWAYS" />
     </VBox>
 
-    <VBox fx:id="clientProfilePanelPlaceholder" styleClass="pane">
-
-    </VBox>
+    <VBox fx:id="clientProfilePanelPlaceholder" styleClass="pane" />
 </HBox>

--- a/src/main/resources/view/DashboardDisplay.fxml
+++ b/src/main/resources/view/DashboardDisplay.fxml
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+
+<?import javafx.scene.chart.PieChart?>
+<?import javafx.scene.control.Label?>
+<?import javafx.scene.layout.HBox?>
+<?import javafx.scene.layout.VBox?>
+<HBox xmlns="http://javafx.com/javafx" xmlns:fx="http://javafx.com/fxml/1" stylesheets="@css/dashboard.css">
+    <VBox styleClass="charts">
+        <Label text="Interaction Statistics"/>
+        <PieChart fx:id="pieChart" legendVisible="false"/>
+    </VBox>
+</HBox>

--- a/src/main/resources/view/DashboardDisplay.fxml
+++ b/src/main/resources/view/DashboardDisplay.fxml
@@ -4,9 +4,46 @@
 <?import javafx.scene.control.Label?>
 <?import javafx.scene.layout.HBox?>
 <?import javafx.scene.layout.VBox?>
+<?import javafx.scene.chart.BarChart?>
+<?import javafx.scene.chart.CategoryAxis?>
+<?import javafx.scene.chart.NumberAxis?>
+<?import javafx.scene.text.Text?>
+
 <HBox xmlns="http://javafx.com/javafx" xmlns:fx="http://javafx.com/fxml/1" stylesheets="@css/dashboard.css">
-    <VBox styleClass="charts">
-        <Label text="Interaction Statistics"/>
-        <PieChart fx:id="pieChart" legendVisible="false"/>
+    <VBox styleClass="stats">
+        <HBox spacing="8">
+            <VBox styleClass="stats-card">
+                <Label text="Clients" styleClass="stats-title"/>
+                <Text styleClass="subtitle">uncontacted / contacting / closed</Text>
+                <HBox alignment="CENTER_LEFT">
+                    <Label fx:id="uncontacted" id="uncontacted" styleClass="big-number"/>
+                    <Label text=" / " styleClass="big-number"/>
+                    <Label fx:id="contacting" id="contacting" styleClass="big-number"/>
+                    <Label text=" / " styleClass="big-number"/>
+                    <Label fx:id="closed" id="closed" styleClass="big-number"/>
+                </HBox>
+            </VBox>
+            <VBox styleClass="stats-card">
+                <Label text="Average interactions" styleClass="stats-title"/>
+                <Text styleClass="subtitle">per client</Text>
+                <Label fx:id="interactionsPerClient" styleClass="big-number" style="-fx-text-fill: #85c1e9;"/>
+            </VBox>
+        </HBox>
+
+
+        <VBox alignment="CENTER">
+            <Label text="Interaction Outcomes" styleClass="chart-title"/>
+            <PieChart fx:id="pieChart" legendVisible="false"/>
+        </VBox>
+
+        <BarChart fx:id="barChart" legendVisible="false" horizontalGridLinesVisible="false"
+                  verticalGridLinesVisible="false">
+            <xAxis>
+                <CategoryAxis fx:id="xAxis" side="BOTTOM"/>
+            </xAxis>
+            <yAxis>
+                <NumberAxis fx:id="yAxis" side="LEFT"/>
+            </yAxis>
+        </BarChart>
     </VBox>
 </HBox>

--- a/src/main/resources/view/MainWindow.fxml
+++ b/src/main/resources/view/MainWindow.fxml
@@ -45,7 +45,7 @@
           </padding>
         </StackPane>
 
-        <StackPane VBox.vgrow="ALWAYS" fx:id="contentDisplayPlaceholder" styleClass="pane" />
+        <StackPane fx:id="content" VBox.vgrow="ALWAYS" styleClass="pane" />
 
         <StackPane fx:id="statusbarPlaceholder" VBox.vgrow="NEVER" />
       </VBox>

--- a/src/main/resources/view/css/dashboard.css
+++ b/src/main/resources/view/css/dashboard.css
@@ -1,0 +1,13 @@
+.charts {
+    -fx-padding: 20px;
+}
+
+.charts .label {
+    -fx-font-size: 20px;
+    -fx-font-weight: bold;
+    -fx-text-fill: white;
+}
+
+.chart-pie-label {
+    -fx-fill: white;
+}

--- a/src/main/resources/view/css/dashboard.css
+++ b/src/main/resources/view/css/dashboard.css
@@ -1,13 +1,66 @@
-.charts {
-    -fx-padding: 20px;
+.label {
+    -fx-text-fill: white;
 }
 
-.charts .label {
+.stats {
+    -fx-padding: 20px;
+    -fx-spacing: 16px;
+}
+
+.stats-card {
+    -fx-padding: 16px;
+    -fx-background-color: #555555;
+    -fx-background-radius: 8px;
+}
+
+.stats-title {
     -fx-font-size: 20px;
     -fx-font-weight: bold;
-    -fx-text-fill: white;
+}
+
+.subtitle {
+    -fx-font-size: 14px;
+    -fx-fill: #AAAAAA;
+}
+
+.big-number {
+    -fx-font-size: 32px;
+    -fx-font-weight: bold;
+}
+
+.chart-title {
+    -fx-font-size: 24px;
+    -fx-font-weight: bold;
 }
 
 .chart-pie-label {
     -fx-fill: white;
+}
+
+.axis {
+    -fx-tick-label-fill: white;
+}
+
+.bar-chart .label {
+    -fx-font-size: 16px;
+}
+
+.bar-chart .chart-plot-background {
+    -fx-background-color: transparent;
+}
+
+.chart-bar {
+    -fx-background-color: #85c1e9;
+}
+
+#uncontacted {
+    -fx-text-fill: #ffffff;
+}
+
+#contacting {
+    -fx-text-fill: #54A954;
+}
+
+#closed {
+    -fx-text-fill: #BBBBBB;
 }

--- a/src/test/java/seedu/address/logic/commands/CommandResultTest.java
+++ b/src/test/java/seedu/address/logic/commands/CommandResultTest.java
@@ -14,7 +14,7 @@ public class CommandResultTest {
 
         // same values -> returns true
         assertTrue(commandResult.equals(new CommandResult("feedback")));
-        assertTrue(commandResult.equals(new CommandResult("feedback", false, false)));
+        assertTrue(commandResult.equals(new CommandResult("feedback", false, false, false)));
 
         // same object -> returns true
         assertTrue(commandResult.equals(commandResult));
@@ -29,10 +29,10 @@ public class CommandResultTest {
         assertFalse(commandResult.equals(new CommandResult("different")));
 
         // different showHelp value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", true, false)));
+        assertFalse(commandResult.equals(new CommandResult("feedback", false, true, false)));
 
         // different exit value -> returns false
-        assertFalse(commandResult.equals(new CommandResult("feedback", false, true)));
+        assertFalse(commandResult.equals(new CommandResult("feedback", false, false, true)));
     }
 
     @Test
@@ -46,10 +46,10 @@ public class CommandResultTest {
         assertNotEquals(commandResult.hashCode(), new CommandResult("different").hashCode());
 
         // different showHelp value -> returns different hashcode
-        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", true, false).hashCode());
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, true, false).hashCode());
 
         // different exit value -> returns different hashcode
-        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, true).hashCode());
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, false, true).hashCode());
     }
 
     @Test

--- a/src/test/java/seedu/address/logic/commands/CommandResultTest.java
+++ b/src/test/java/seedu/address/logic/commands/CommandResultTest.java
@@ -28,6 +28,9 @@ public class CommandResultTest {
         // different feedbackToUser value -> returns false
         assertFalse(commandResult.equals(new CommandResult("different")));
 
+        // different showDashboard value -> returns false
+        assertFalse(commandResult.equals(new CommandResult("feedback", true, false, false)));
+
         // different showHelp value -> returns false
         assertFalse(commandResult.equals(new CommandResult("feedback", false, true, false)));
 
@@ -45,6 +48,9 @@ public class CommandResultTest {
         // different feedbackToUser value -> returns different hashcode
         assertNotEquals(commandResult.hashCode(), new CommandResult("different").hashCode());
 
+        // different showDashboard value -> returns different hashcode
+        assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", true, false, false).hashCode());
+
         // different showHelp value -> returns different hashcode
         assertNotEquals(commandResult.hashCode(), new CommandResult("feedback", false, true, false).hashCode());
 
@@ -56,7 +62,7 @@ public class CommandResultTest {
     public void toStringMethod() {
         CommandResult commandResult = new CommandResult("feedback");
         String expected = CommandResult.class.getCanonicalName() + "{feedbackToUser="
-                + commandResult.getFeedbackToUser() + ", showHelp=" + commandResult.isShowHelp()
+                + commandResult.getFeedbackToUser() + ", showDashboard=" + commandResult.isShowDashboard() + ", showHelp=" + commandResult.isShowHelp()
                 + ", exit=" + commandResult.isExit() + "}";
         assertEquals(expected, commandResult.toString());
     }

--- a/src/test/java/seedu/address/logic/commands/CommandResultTest.java
+++ b/src/test/java/seedu/address/logic/commands/CommandResultTest.java
@@ -61,9 +61,10 @@ public class CommandResultTest {
     @Test
     public void toStringMethod() {
         CommandResult commandResult = new CommandResult("feedback");
-        String expected = CommandResult.class.getCanonicalName() + "{feedbackToUser="
-                + commandResult.getFeedbackToUser() + ", showDashboard=" + commandResult.isShowDashboard() + ", showHelp=" + commandResult.isShowHelp()
-                + ", exit=" + commandResult.isExit() + "}";
+        String expected =
+                CommandResult.class.getCanonicalName() + "{feedbackToUser=" + commandResult.getFeedbackToUser()
+                        + ", showDashboard=" + commandResult.isShowDashboard() + ", showHelp="
+                        + commandResult.isShowHelp() + ", exit=" + commandResult.isExit() + "}";
         assertEquals(expected, commandResult.toString());
     }
 }

--- a/src/test/java/seedu/address/logic/commands/DashboardCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DashboardCommandTest.java
@@ -1,0 +1,20 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.DashboardCommand.SHOWING_DASHBOARD_MESSAGE;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+
+public class DashboardCommandTest {
+    private Model model = new ModelManager();
+    private Model expectedModel = new ModelManager();
+
+    @Test
+    public void execute_dashboard_success() {
+        CommandResult expectedCommandResult = new CommandResult(SHOWING_DASHBOARD_MESSAGE, true, false, false);
+        assertCommandSuccess(new DashboardCommand(), model, expectedCommandResult, expectedModel);
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/ExitCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/ExitCommandTest.java
@@ -14,7 +14,7 @@ public class ExitCommandTest {
 
     @Test
     public void execute_exit_success() {
-        CommandResult expectedCommandResult = new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, true);
+        CommandResult expectedCommandResult = new CommandResult(MESSAGE_EXIT_ACKNOWLEDGEMENT, false, false, true);
         assertCommandSuccess(new ExitCommand(), model, expectedCommandResult, expectedModel);
     }
 }

--- a/src/test/java/seedu/address/logic/commands/HelpCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/HelpCommandTest.java
@@ -14,7 +14,7 @@ public class HelpCommandTest {
 
     @Test
     public void execute_help_success() {
-        CommandResult expectedCommandResult = new CommandResult(SHOWING_HELP_MESSAGE, true, false);
+        CommandResult expectedCommandResult = new CommandResult(SHOWING_HELP_MESSAGE, false, true, false);
         assertCommandSuccess(new HelpCommand(), model, expectedCommandResult, expectedModel);
     }
 }


### PR DESCRIPTION
Adds a dashboard UI that is shown on app launch, as well as whenever the `dashboard` command is entered.

The `isDashboardDirty` flag is still not handled yet. Showing updated data works fine for now since any commands that touch the `personList` will force a switch to the client view. So the next time the dashboard is shown, it will fetch the latest client data.

Part of #57, part of #58, fixes #98.

Features:

- [x] Charts
- [x] Client statistics
- [x] Handle empty states
- ~~Reminders/upcoming events~~ (will be done by @lilozz2)

Current state:

<img width="1144" alt="image" src="https://github.com/AY2324S1-CS2103T-F11-4/tp/assets/25928055/5221d52b-9150-4bb1-afb8-1ff1d7689a0f">
