### PR TITLE
Add JSON parsing for additional fields

### DIFF
--- a/src/main/java/seedu/address/model/person/Details.java
+++ b/src/main/java/seedu/address/model/person/Details.java
@@ -7,7 +7,12 @@ public class Details {
 
     public static final String MESSAGE_CONSTRAINTS = "Details should only contain alphanumeric characters "
             + "and spaces, and it should not be blank";
-    public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";
+
+    /*
+     * The first character of the details must not be a whitespace,
+     * otherwise " " (a blank string) becomes a valid input.
+     */
+    public static final String VALIDATION_REGEX = "[^\\s].*";
 
     public final String value;
 

--- a/src/main/java/seedu/address/model/person/Name.java
+++ b/src/main/java/seedu/address/model/person/Name.java
@@ -13,7 +13,7 @@ public class Name {
             "Names should only contain alphanumeric characters and spaces, and it should not be blank";
 
     /*
-     * The first character of the address must not be a whitespace,
+     * The first character of the name must not be a whitespace,
      * otherwise " " (a blank string) becomes a valid input.
      */
     public static final String VALIDATION_REGEX = "[\\p{Alnum}][\\p{Alnum} ]*";

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -7,6 +7,8 @@ import java.util.Set;
 import java.util.stream.Collectors;
 
 import com.fasterxml.jackson.annotation.JsonCreator;
+import com.fasterxml.jackson.annotation.JsonInclude;
+import com.fasterxml.jackson.annotation.JsonInclude.Include;
 import com.fasterxml.jackson.annotation.JsonProperty;
 
 import seedu.address.commons.exceptions.IllegalValueException;
@@ -36,10 +38,20 @@ class JsonAdaptedPerson {
     private final String email;
     private final String address;
     private final List<JsonAdaptedTag> tags = new ArrayList<>();
+
+    @JsonInclude(Include.NON_NULL)
     private final String lead;
+
+    @JsonInclude(Include.NON_NULL)
     private final String telegram;
+
+    @JsonInclude(Include.NON_NULL)
     private final String profession;
+
+    @JsonInclude(Include.NON_NULL)
     private final String income;
+
+    @JsonInclude(Include.NON_NULL)
     private final String details;
     private final List<JsonAdaptedInteraction> interactions = new ArrayList<>();
 

--- a/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
+++ b/src/main/java/seedu/address/storage/JsonAdaptedPerson.java
@@ -11,10 +11,15 @@ import com.fasterxml.jackson.annotation.JsonProperty;
 
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.person.Address;
+import seedu.address.model.person.Details;
 import seedu.address.model.person.Email;
+import seedu.address.model.person.Income;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
+import seedu.address.model.person.Person.PersonBuilder;
 import seedu.address.model.person.Phone;
+import seedu.address.model.person.Profession;
+import seedu.address.model.person.TelegramHandle;
 import seedu.address.model.person.interaction.Interaction;
 import seedu.address.model.person.lead.Lead;
 import seedu.address.model.tag.Tag;
@@ -32,7 +37,10 @@ class JsonAdaptedPerson {
     private final String address;
     private final List<JsonAdaptedTag> tags = new ArrayList<>();
     private final String lead;
-    // private final JsonAdaptedInteractionList interactions;
+    private final String telegram;
+    private final String profession;
+    private final String income;
+    private final String details;
     private final List<JsonAdaptedInteraction> interactions = new ArrayList<>();
 
     /**
@@ -42,6 +50,8 @@ class JsonAdaptedPerson {
     public JsonAdaptedPerson(@JsonProperty("name") String name, @JsonProperty("phone") String phone,
             @JsonProperty("email") String email, @JsonProperty("address") String address,
             @JsonProperty("tags") List<JsonAdaptedTag> tags, @JsonProperty("lead") String lead,
+            @JsonProperty("telegram") String telegram, @JsonProperty("profession") String profession,
+            @JsonProperty("income") String income, @JsonProperty("details") String details,
             @JsonProperty("interactions") List<JsonAdaptedInteraction> interactions) {
         this.name = name;
         this.phone = phone;
@@ -50,7 +60,14 @@ class JsonAdaptedPerson {
         if (tags != null) {
             this.tags.addAll(tags);
         }
+
+        // Optional fields
         this.lead = lead;
+        this.telegram = telegram;
+        this.profession = profession;
+        this.income = income;
+        this.details = details;
+
         if (interactions != null) {
             this.interactions.addAll(interactions);
         }
@@ -67,11 +84,14 @@ class JsonAdaptedPerson {
         tags.addAll(source.getTags().stream()
                 .map(JsonAdaptedTag::new)
                 .collect(Collectors.toList()));
-        if (source.getLead() == null) {
-            lead = "";
-        } else {
-            lead = source.getLead().toString().toLowerCase();
-        }
+
+        // Optional fields
+        lead = source.getLead() == null ? null : source.getLead().toString();
+        telegram = source.getTelegram() == null ? null : source.getTelegram().toString();
+        profession = source.getProfession() == null ? null : source.getProfession().toString();
+        income = source.getIncome() == null ? null : source.getIncome().toString();
+        details = source.getDetails() == null ? null : source.getDetails().toString();
+
         interactions.addAll(source.getInteractions().stream()
             .map(JsonAdaptedInteraction::new)
             .collect(Collectors.toList()));
@@ -131,13 +151,40 @@ class JsonAdaptedPerson {
 
         final Set<Tag> modelTags = new HashSet<>(personTags);
 
-        Person.PersonBuilder personBuilder =
-                new Person.PersonBuilder(modelName, modelPhone, modelEmail, modelAddress, modelTags);
+        PersonBuilder personBuilder = new PersonBuilder(modelName, modelPhone, modelEmail, modelAddress, modelTags);
 
-        if (lead != null && !lead.isEmpty()) {
-            final Lead modelLead = new Lead(lead);
-            personBuilder = personBuilder.withLead(modelLead);
+        // Optional fields
+        if (lead != null) {
+            if (!Lead.isValidLead(lead)) {
+                throw new IllegalValueException(String.format(Lead.MESSAGE_CONSTRAINTS));
+            }
+            personBuilder = personBuilder.withLead(new Lead(lead));
         }
+        if (telegram != null) {
+            if (!TelegramHandle.isValidTelegramHandle(telegram)) {
+                throw new IllegalValueException(String.format(TelegramHandle.MESSAGE_CONSTRAINTS));
+            }
+            personBuilder = personBuilder.withTelegram(new TelegramHandle(telegram));
+        }
+        if (profession != null) {
+            if (!Profession.isValidProfession(profession)) {
+                throw new IllegalValueException(String.format(Profession.MESSAGE_CONSTRAINTS));
+            }
+            personBuilder = personBuilder.withProfession(new Profession(profession));
+        }
+        if (income != null) {
+            if (!Income.isValidIncome(income)) {
+                throw new IllegalValueException(String.format(Income.MESSAGE_CONSTRAINTS));
+            }
+            personBuilder = personBuilder.withIncome(new Income(Integer.valueOf(income)));
+        }
+        if (details != null) {
+            if (!Details.isValidDetails(details)) {
+                throw new IllegalValueException(String.format(Details.MESSAGE_CONSTRAINTS));
+            }
+            personBuilder = personBuilder.withDetails(new Details(details));
+        }
+
         personBuilder.withInteractions(modelInteractions);
         return personBuilder.build();
     }

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -2,7 +2,6 @@ package seedu.address.storage;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static seedu.address.model.person.interaction.Interaction.Outcome.MESSAGE_CONSTRAINTS;
-import static seedu.address.storage.JsonAdaptedInteraction.INTERACTION_MISSING_FIELD_MESSAGE_FORMAT;
 import static seedu.address.storage.JsonAdaptedInteraction.INVALID_DATE_FIELD_MESSAGE;
 import static seedu.address.storage.JsonAdaptedPerson.PERSON_MISSING_FIELD_MESSAGE_FORMAT;
 import static seedu.address.testutil.Assert.assertThrows;
@@ -27,15 +26,22 @@ public class JsonAdaptedPersonTest {
     private static final String INVALID_EMAIL = "example.com";
     private static final String INVALID_TAG = "#friend";
     private static final String INVALID_LEAD = "medium";
+    private static final String INVALID_TELEGRAM = "~rachel";
+    private static final String INVALID_PROFESSION = "d@ctor";
+    private static final String INVALID_INCOME = "lots of money";
 
     private static final String VALID_NAME = BENSON.getName().toString();
     private static final String VALID_PHONE = BENSON.getPhone().toString();
     private static final String VALID_EMAIL = BENSON.getEmail().toString();
     private static final String VALID_ADDRESS = BENSON.getAddress().toString();
-    private static final String VALID_LEAD = BENSON.getLead().toString();
     private static final List<JsonAdaptedTag> VALID_TAGS = BENSON.getTags().stream()
             .map(JsonAdaptedTag::new)
             .collect(Collectors.toList());
+    private static final String VALID_LEAD = BENSON.getLead().toString();
+    private static final String VALID_TELEGRAM = BENSON.getTelegram().toString();
+    private static final String VALID_PROFESSION = BENSON.getProfession().toString();
+    private static final String VALID_INCOME = BENSON.getIncome().toString();
+    private static final String VALID_DETAILS = BENSON.getDetails().toString();
     private static final List<JsonAdaptedInteraction> VALID_INTERACTIONS = BENSON.getInteractions().stream()
             .map(JsonAdaptedInteraction::new)
             .collect(Collectors.toList());
@@ -49,8 +55,8 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidName_throwsIllegalValueException() {
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                                    VALID_TAGS, VALID_LEAD, VALID_INTERACTIONS);
+                new JsonAdaptedPerson(INVALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_LEAD,
+                        VALID_TELEGRAM, VALID_PROFESSION, VALID_INCOME, VALID_DETAILS, VALID_INTERACTIONS);
         String expectedMessage = Name.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -58,8 +64,8 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullName_throwsIllegalValueException() {
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(null, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                                    VALID_TAGS, VALID_LEAD, VALID_INTERACTIONS);
+                new JsonAdaptedPerson(null, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_LEAD,
+                        VALID_TELEGRAM, VALID_PROFESSION, VALID_INCOME, VALID_DETAILS, VALID_INTERACTIONS);
         String expectedMessage = String.format(PERSON_MISSING_FIELD_MESSAGE_FORMAT, Name.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -67,8 +73,8 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidPhone_throwsIllegalValueException() {
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                                    VALID_TAGS, VALID_LEAD, VALID_INTERACTIONS);
+                new JsonAdaptedPerson(VALID_NAME, INVALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_LEAD,
+                        VALID_TELEGRAM, VALID_PROFESSION, VALID_INCOME, VALID_DETAILS, VALID_INTERACTIONS);
         String expectedMessage = Phone.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -76,8 +82,8 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullPhone_throwsIllegalValueException() {
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, null, VALID_EMAIL, VALID_ADDRESS,
-                                    VALID_TAGS, VALID_LEAD, VALID_INTERACTIONS);
+                new JsonAdaptedPerson(VALID_NAME, null, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_LEAD,
+                        VALID_TELEGRAM, VALID_PROFESSION, VALID_INCOME, VALID_DETAILS, VALID_INTERACTIONS);
         String expectedMessage = String.format(PERSON_MISSING_FIELD_MESSAGE_FORMAT, Phone.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -85,8 +91,8 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidEmail_throwsIllegalValueException() {
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_ADDRESS,
-                                    VALID_TAGS, VALID_LEAD, VALID_INTERACTIONS);
+                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, INVALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_LEAD,
+                        VALID_TELEGRAM, VALID_PROFESSION, VALID_INCOME, VALID_DETAILS, VALID_INTERACTIONS);
         String expectedMessage = Email.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -94,8 +100,8 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullEmail_throwsIllegalValueException() {
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, null, VALID_ADDRESS,
-                                    VALID_TAGS, VALID_LEAD, VALID_INTERACTIONS);
+                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, null, VALID_ADDRESS, VALID_TAGS, VALID_LEAD,
+                        VALID_TELEGRAM, VALID_PROFESSION, VALID_INCOME, VALID_DETAILS, VALID_INTERACTIONS);
         String expectedMessage = String.format(PERSON_MISSING_FIELD_MESSAGE_FORMAT, Email.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -103,8 +109,8 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_invalidAddress_throwsIllegalValueException() {
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_ADDRESS,
-                                    VALID_TAGS, VALID_LEAD, VALID_INTERACTIONS);
+                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, INVALID_ADDRESS, VALID_TAGS, VALID_LEAD,
+                        VALID_TELEGRAM, VALID_PROFESSION, VALID_INCOME, VALID_DETAILS, VALID_INTERACTIONS);
         String expectedMessage = Address.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -112,8 +118,8 @@ public class JsonAdaptedPersonTest {
     @Test
     public void toModelType_nullAddress_throwsIllegalValueException() {
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, null,
-                                    VALID_TAGS, VALID_LEAD, VALID_INTERACTIONS);
+                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, null, VALID_TAGS, VALID_LEAD,
+                        VALID_TELEGRAM, VALID_PROFESSION, VALID_INCOME, VALID_DETAILS, VALID_INTERACTIONS);
         String expectedMessage = String.format(PERSON_MISSING_FIELD_MESSAGE_FORMAT, Address.class.getSimpleName());
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
@@ -123,74 +129,63 @@ public class JsonAdaptedPersonTest {
         List<JsonAdaptedTag> invalidTags = new ArrayList<>(VALID_TAGS);
         invalidTags.add(new JsonAdaptedTag(INVALID_TAG));
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                                    invalidTags, VALID_LEAD, VALID_INTERACTIONS);
+                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, invalidTags, VALID_LEAD,
+                        VALID_TELEGRAM, VALID_PROFESSION, VALID_INCOME, VALID_DETAILS, VALID_INTERACTIONS);
         assertThrows(IllegalValueException.class, person::toModelType);
     }
 
     @Test
     public void toModelType_invalidLead_throwsIllegalValueException() {
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                                    VALID_TAGS, INVALID_LEAD, VALID_INTERACTIONS);
+                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, INVALID_LEAD,
+                        VALID_TELEGRAM, VALID_PROFESSION, VALID_INCOME, VALID_DETAILS, VALID_INTERACTIONS);
         String expectedMessage = "Lead should only take values hot|warm|cold";
-        assertThrows(IllegalArgumentException.class, expectedMessage, person::toModelType);
+        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullLead_returnsPerson() throws Exception {
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                                    VALID_TAGS, null, VALID_INTERACTIONS);
+                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, null,
+                        VALID_TELEGRAM, VALID_PROFESSION, VALID_INCOME, VALID_DETAILS, VALID_INTERACTIONS);
         assertEquals(BENSON, person.toModelType());
     }
 
     @Test
-    public void toModelType_justNullInteraction_doesNotThrowException() throws Exception {
+    public void toModelType_emptyInteractionNote_returnsPerson() throws Exception {
         List<JsonAdaptedInteraction> validInteractions = new ArrayList<>();
         validInteractions.add(new JsonAdaptedInteraction("", "INTERESTED", "27-Oct-2023"));
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                                    VALID_TAGS, VALID_LEAD, validInteractions);
+                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_LEAD,
+                        VALID_TELEGRAM, VALID_PROFESSION, VALID_INCOME, VALID_DETAILS, validInteractions);
         assertEquals(BENSON, person.toModelType());
     }
 
     @Test
-    public void toModelType_nullOutcome_throwIllegalValue() throws Exception {
+    public void toModelType_emptyInteractionOutcome_throwsIllegalValueException() throws Exception {
         List<JsonAdaptedInteraction> validInteractions = new ArrayList<>(VALID_INTERACTIONS);
         validInteractions.add(new JsonAdaptedInteraction("Valid Note", "", "27-Oct-2023"));
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                                    VALID_TAGS, VALID_LEAD, validInteractions);
+                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_LEAD,
+                        VALID_TELEGRAM, VALID_PROFESSION, VALID_INCOME, VALID_DETAILS, validInteractions);
         assertThrows(IllegalValueException.class, MESSAGE_CONSTRAINTS, person::toModelType);
     }
 
     @Test
-    public void toModelType_invalidOutcome_throwsIllegalValueException() {
+    public void toModelType_invalidInteractionOutcome_throwsIllegalValueException() {
         List<JsonAdaptedInteraction> invalidInteractions = new ArrayList<>(VALID_INTERACTIONS);
         invalidInteractions.add(new JsonAdaptedInteraction("Valid Note", " ", "27-Oct-2023"));
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                                    VALID_TAGS, VALID_LEAD, invalidInteractions);
+                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_LEAD,
+                        VALID_TELEGRAM, VALID_PROFESSION, VALID_INCOME, VALID_DETAILS, invalidInteractions);
         assertThrows(IllegalValueException.class, MESSAGE_CONSTRAINTS, person::toModelType);
-    }
-
-    @Test
-    public void toModelType_nullOutcomeAndInteraction_throwsIllegalValue() throws Exception {
-        List<JsonAdaptedInteraction> validInteractions = new ArrayList<>(VALID_INTERACTIONS);
-        validInteractions.add(new JsonAdaptedInteraction("", "", "27-Oct-2023"));
-        JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                                    VALID_TAGS, VALID_LEAD, validInteractions);
-        String expectedMessage = String.format(INTERACTION_MISSING_FIELD_MESSAGE_FORMAT, "interactionNote or outcome");
-        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
     @Test
     public void toModelType_nullInteractions_returnsPerson() throws Exception {
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                                    VALID_TAGS, VALID_LEAD, null);
+                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_LEAD,
+                        VALID_TELEGRAM, VALID_PROFESSION, VALID_INCOME, VALID_DETAILS, null);
         assertEquals(BENSON, person.toModelType());
     }
 
@@ -199,8 +194,8 @@ public class JsonAdaptedPersonTest {
         List<JsonAdaptedInteraction> invalidInteractions = new ArrayList<>(VALID_INTERACTIONS);
         invalidInteractions.add(new JsonAdaptedInteraction(" ", "INTERESTED", " "));
         JsonAdaptedPerson person =
-                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS,
-                                    VALID_TAGS, VALID_LEAD, invalidInteractions);
+                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_LEAD,
+                        VALID_TELEGRAM, VALID_PROFESSION, VALID_INCOME, VALID_DETAILS, invalidInteractions);
         assertThrows(IllegalValueException.class, INVALID_DATE_FIELD_MESSAGE, person::toModelType);
     }
 }

--- a/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
+++ b/src/test/java/seedu/address/storage/JsonAdaptedPersonTest.java
@@ -1,6 +1,7 @@
 package seedu.address.storage;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static seedu.address.model.person.interaction.Interaction.Outcome.MESSAGE_CONSTRAINTS;
 import static seedu.address.storage.JsonAdaptedInteraction.INVALID_DATE_FIELD_MESSAGE;
 import static seedu.address.storage.JsonAdaptedPerson.PERSON_MISSING_FIELD_MESSAGE_FORMAT;
@@ -16,8 +17,13 @@ import org.junit.jupiter.api.Test;
 import seedu.address.commons.exceptions.IllegalValueException;
 import seedu.address.model.person.Address;
 import seedu.address.model.person.Email;
+import seedu.address.model.person.Income;
 import seedu.address.model.person.Name;
+import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
+import seedu.address.model.person.Profession;
+import seedu.address.model.person.TelegramHandle;
+import seedu.address.model.person.lead.Lead;
 
 public class JsonAdaptedPersonTest {
     private static final String INVALID_NAME = "R@chel";
@@ -139,7 +145,7 @@ public class JsonAdaptedPersonTest {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, INVALID_LEAD,
                         VALID_TELEGRAM, VALID_PROFESSION, VALID_INCOME, VALID_DETAILS, VALID_INTERACTIONS);
-        String expectedMessage = "Lead should only take values hot|warm|cold";
+        String expectedMessage = Lead.MESSAGE_CONSTRAINTS;
         assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
     }
 
@@ -148,7 +154,76 @@ public class JsonAdaptedPersonTest {
         JsonAdaptedPerson person =
                 new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, null,
                         VALID_TELEGRAM, VALID_PROFESSION, VALID_INCOME, VALID_DETAILS, VALID_INTERACTIONS);
-        assertEquals(BENSON, person.toModelType());
+        Person modelPerson = person.toModelType();
+        assertEquals(BENSON, modelPerson);
+        assertNull(modelPerson.getLead());
+    }
+
+    @Test
+    public void toModelType_invalidTelegram_throwsIllegalValueException() {
+        JsonAdaptedPerson person =
+                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_LEAD,
+                        INVALID_TELEGRAM, VALID_PROFESSION, VALID_INCOME, VALID_DETAILS, VALID_INTERACTIONS);
+        String expectedMessage = TelegramHandle.MESSAGE_CONSTRAINTS;
+        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
+    }
+
+    @Test
+    public void toModelType_nullTelegram_returnsPerson() throws Exception {
+        JsonAdaptedPerson person =
+                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_LEAD,
+                        null, VALID_PROFESSION, VALID_INCOME, VALID_DETAILS, VALID_INTERACTIONS);
+        Person modelPerson = person.toModelType();
+        assertEquals(BENSON, modelPerson);
+        assertNull(modelPerson.getTelegram());
+    }
+
+    @Test
+    public void toModelType_invalidProfession_throwsIllegalValueException() {
+        JsonAdaptedPerson person =
+                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_LEAD,
+                        VALID_TELEGRAM, INVALID_PROFESSION, VALID_INCOME, VALID_DETAILS, VALID_INTERACTIONS);
+        String expectedMessage = Profession.MESSAGE_CONSTRAINTS;
+        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
+    }
+
+    @Test
+    public void toModelType_nullProfession_returnsPerson() throws Exception {
+        JsonAdaptedPerson person =
+                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_LEAD,
+                        VALID_TELEGRAM, null, VALID_INCOME, VALID_DETAILS, VALID_INTERACTIONS);
+        Person modelPerson = person.toModelType();
+        assertEquals(BENSON, modelPerson);
+        assertNull(modelPerson.getProfession());
+    }
+
+    @Test
+    public void toModelType_invalidIncome_throwsIllegalValueException() {
+        JsonAdaptedPerson person =
+                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_LEAD,
+                        VALID_TELEGRAM, VALID_PROFESSION, INVALID_INCOME, VALID_DETAILS, VALID_INTERACTIONS);
+        String expectedMessage = Income.MESSAGE_CONSTRAINTS;
+        assertThrows(IllegalValueException.class, expectedMessage, person::toModelType);
+    }
+
+    @Test
+    public void toModelType_nullIncome_returnsPerson() throws Exception {
+        JsonAdaptedPerson person =
+                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_LEAD,
+                        VALID_TELEGRAM, VALID_PROFESSION, null, VALID_DETAILS, VALID_INTERACTIONS);
+        Person modelPerson = person.toModelType();
+        assertEquals(BENSON, modelPerson);
+        assertNull(modelPerson.getIncome());
+    }
+
+    @Test
+    public void toModelType_nullDetails_returnsPerson() throws Exception {
+        JsonAdaptedPerson person =
+                new JsonAdaptedPerson(VALID_NAME, VALID_PHONE, VALID_EMAIL, VALID_ADDRESS, VALID_TAGS, VALID_LEAD,
+                        VALID_TELEGRAM, VALID_PROFESSION, VALID_INCOME, null, VALID_INTERACTIONS);
+        Person modelPerson = person.toModelType();
+        assertEquals(BENSON, modelPerson);
+        assertNull(modelPerson.getDetails());
     }
 
     @Test

--- a/src/test/java/seedu/address/testutil/PersonBuilder.java
+++ b/src/test/java/seedu/address/testutil/PersonBuilder.java
@@ -6,10 +6,14 @@ import java.util.List;
 import java.util.Set;
 
 import seedu.address.model.person.Address;
+import seedu.address.model.person.Details;
 import seedu.address.model.person.Email;
+import seedu.address.model.person.Income;
 import seedu.address.model.person.Name;
 import seedu.address.model.person.Person;
 import seedu.address.model.person.Phone;
+import seedu.address.model.person.Profession;
+import seedu.address.model.person.TelegramHandle;
 import seedu.address.model.person.interaction.Interaction;
 import seedu.address.model.person.lead.Lead;
 import seedu.address.model.tag.Tag;
@@ -19,19 +23,26 @@ import seedu.address.model.util.SampleDataUtil;
  * A utility class to help with building Person objects.
  */
 public class PersonBuilder {
-
     public static final String DEFAULT_NAME = "Amy Bee";
     public static final String DEFAULT_PHONE = "85355255";
     public static final String DEFAULT_EMAIL = "amy@gmail.com";
     public static final String DEFAULT_ADDRESS = "123, Jurong West Ave 6, #08-111";
     public static final String DEFAULT_LEAD = "cold";
+    public static final String DEFAULT_TELEGRAM = "@amybee";
+    public static final String DEFAULT_PROFESSION = "teacher";
+    public static final String DEFAULT_INCOME = "4000";
+    public static final String DEFAULT_DETAILS = "Likes to play sports";
 
     private Name name;
     private Phone phone;
     private Email email;
     private Address address;
-    private Lead lead;
     private Set<Tag> tags;
+    private Lead lead;
+    private TelegramHandle telegram;
+    private Profession profession;
+    private Income income;
+    private Details details;
     private List<Interaction> interactions;
 
     /**
@@ -42,8 +53,12 @@ public class PersonBuilder {
         phone = new Phone(DEFAULT_PHONE);
         email = new Email(DEFAULT_EMAIL);
         address = new Address(DEFAULT_ADDRESS);
-        lead = new Lead(DEFAULT_LEAD);
         tags = new HashSet<>();
+        lead = new Lead(DEFAULT_LEAD);
+        telegram = new TelegramHandle(DEFAULT_TELEGRAM);
+        profession = new Profession(DEFAULT_PROFESSION);
+        income = new Income(Integer.valueOf(DEFAULT_INCOME));
+        details = new Details(DEFAULT_DETAILS);
         interactions = new ArrayList<>();
     }
 
@@ -55,8 +70,12 @@ public class PersonBuilder {
         phone = personToCopy.getPhone();
         email = personToCopy.getEmail();
         address = personToCopy.getAddress();
-        lead = personToCopy.getLead();
         tags = new HashSet<>(personToCopy.getTags());
+        lead = personToCopy.getLead();
+        telegram = personToCopy.getTelegram();
+        profession = personToCopy.getProfession();
+        income = personToCopy.getIncome();
+        details = personToCopy.getDetails();
         interactions = personToCopy.getInteractions();
     }
 
@@ -65,22 +84,6 @@ public class PersonBuilder {
      */
     public PersonBuilder withName(String name) {
         this.name = new Name(name);
-        return this;
-    }
-
-    /**
-     * Parses the {@code tags} into a {@code Set<Tag>} and set it to the {@code Person} that we are building.
-     */
-    public PersonBuilder withTags(String ... tags) {
-        this.tags = SampleDataUtil.getTagSet(tags);
-        return this;
-    }
-
-    /**
-     * Sets the {@code Address} of the {@code Person} that we are building.
-     */
-    public PersonBuilder withAddress(String address) {
-        this.address = new Address(address);
         return this;
     }
 
@@ -101,10 +104,58 @@ public class PersonBuilder {
     }
 
     /**
+     * Sets the {@code Address} of the {@code Person} that we are building.
+     */
+    public PersonBuilder withAddress(String address) {
+        this.address = new Address(address);
+        return this;
+    }
+
+    /**
+     * Parses the {@code tags} into a {@code Set<Tag>} and set it to the {@code Person} that we are building.
+     */
+    public PersonBuilder withTags(String ... tags) {
+        this.tags = SampleDataUtil.getTagSet(tags);
+        return this;
+    }
+
+    /**
      * Sets the {@code Lead} of the {@code Person} that we are building.
      */
     public PersonBuilder withLead(String lead) {
         this.lead = new Lead(lead);
+        return this;
+    }
+
+    /**
+     * Sets the {@code TelegramHandle} of the {@code Person} that we are building.
+     */
+    public PersonBuilder withTelegram(String telegram) {
+        this.telegram = new TelegramHandle(telegram);
+        return this;
+    }
+
+    /**
+     * Sets the {@code Profession} of the {@code Person} that we are building.
+     */
+    public PersonBuilder withProfession(String profession) {
+        this.profession = new Profession(profession);
+        return this;
+    }
+
+    /**
+     * Sets the {@code Income} of the {@code Person} that we are building.
+     */
+    public PersonBuilder withIncome(String income) {
+        this.income = new Income(Integer.valueOf(income));
+        return this;
+    }
+
+    /**
+     * Sets the {@code Details} of the {@code Person} that we are building.
+     */
+    public PersonBuilder withDetails(String details) {
+        this.details = new Details(details);
         return this;
     }
 
@@ -123,9 +174,8 @@ public class PersonBuilder {
      */
     public Person build() {
         return new Person.PersonBuilder(name, phone, email, address, tags)
-                .withLead(lead)
-                .withInteractions(interactions)
+                .withLead(lead).withTelegram(telegram).withProfession(profession)
+                .withIncome(income).withDetails(details).withInteractions(interactions)
                 .build();
     }
-
 }

--- a/src/test/java/seedu/address/testutil/TypicalPersons.java
+++ b/src/test/java/seedu/address/testutil/TypicalPersons.java
@@ -49,10 +49,9 @@ public class TypicalPersons {
             .withPhone("94351253")
             .withTags("friends").build();
     public static final Person BENSON = new PersonBuilder().withName("Benson Meier")
-            .withAddress("311, Clementi Ave 2, #02-25")
-            .withEmail("johnd@example.com").withPhone("98765432")
-            .withTags("owesMoney", "friends").withLead("warm")
-            .withInteractions(INTERACTION_LIST_ONE).build();
+            .withAddress("311, Clementi Ave 2, #02-25").withEmail("johnd@example.com").withPhone("98765432")
+            .withTags("owesMoney", "friends").withLead("warm").withTelegram("@benson").withProfession("Realtor")
+            .withIncome("300000").withDetails("Benson is rich").withInteractions(INTERACTION_LIST_ONE).build();
     public static final Person CARL = new PersonBuilder().withName("Carl Kurz").withPhone("95352563")
             .withEmail("heinz@example.com").withAddress("wall street").build();
     public static final Person DANIEL = new PersonBuilder().withName("Daniel Meier").withPhone("87652533")


### PR DESCRIPTION
Fixes #70

### Changes
- Add support for saving and parsing optional `Person` fields including `lead`, `telegram`, `profession`, `income` and `details`. If an optional field is null, it will not appear in the JSON object.
- Add testing for `JsonAdaptedPerson` for invalid and null values for the mentioned optional fields.
- `Detail` object now accepts non-alphanumeric characters
