### PR TITLE
Add-EditCommandMacros

### DIFF
--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -33,6 +33,25 @@ public class AddressBookParser {
     private static final Pattern BASIC_COMMAND_FORMAT = Pattern.compile("(?<commandWord>\\S+)(?<arguments>.*)");
     private static final Logger logger = LogsCenter.getLogger(AddressBookParser.class);
 
+    //NOTE DOES NOT WORK FOR TAG
+    private static enum PersonField {
+        NAME("name"),
+        PHONE("phone"),
+        EMAIL("email"),
+        ADDRESS("address"),
+        LEAD("lead"),
+        TELEGRAMHANDLE("telegramHandle"),
+        PROFESSION("profession"),
+        INCOME("income"),
+        DETAILS("details");
+
+        public final String label;
+
+        private PersonField(String label) {
+            this.label = label;
+        }
+    }
+
     /**
      * Parses user input into command for execution.
      *
@@ -88,11 +107,14 @@ public class AddressBookParser {
 
         case HelpCommand.COMMAND_WORD:
             return new HelpCommand();
-
         default:
+            for (PersonField personField : PersonField.values()) {
+                if (commandWord.equals(personField.label)) {
+                    return new EditCommandMacroParser(commandWord).parse(arguments);
+                }
+            }
             logger.finer("This user input caused a ParseException: " + userInput);
             throw new ParseException(MESSAGE_UNKNOWN_COMMAND);
         }
     }
-
 }

--- a/src/main/java/seedu/address/logic/parser/AddressBookParser.java
+++ b/src/main/java/seedu/address/logic/parser/AddressBookParser.java
@@ -40,7 +40,7 @@ public class AddressBookParser {
         EMAIL("email"),
         ADDRESS("address"),
         LEAD("lead"),
-        TELEGRAMHANDLE("telegramHandle"),
+        TELEGRAM_HANDLE("telegramhandle"),
         PROFESSION("profession"),
         INCOME("income"),
         DETAILS("details");

--- a/src/main/java/seedu/address/logic/parser/EditCommandMacroParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandMacroParser.java
@@ -60,7 +60,7 @@ public class EditCommandMacroParser implements Parser<EditCommand> {
         case "lead":
             editPersonDescriptor.setLead(ParserUtil.parseLead(argString));
             break;
-        case "telegram":
+        case "telegramhandle":
             editPersonDescriptor.setTelegram(ParserUtil.parseTelegram(argString));
             break;
         case "profession":

--- a/src/main/java/seedu/address/logic/parser/EditCommandMacroParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandMacroParser.java
@@ -1,0 +1,80 @@
+package seedu.address.logic.parser;
+import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.EditCommand;
+import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
+import seedu.address.logic.parser.exceptions.ParseException;
+
+/**
+ * Parses input arguments and creates a new EditCommand object with only one field to edit
+ */
+public class EditCommandMacroParser implements Parser<EditCommand> {
+
+    public static final String MACRO_MESSAGE_USAGE = "Edit just one field of a client specified by index.\n"
+            + "Parameters: INDEX (must be a positive integer) "
+            + "Edit command macro usage: <Client Field> INDEX <New Value>\n"
+            + "Client Field: name, phone, email, address, telegram, profession, income, details\n"
+            + "Example: name 1 John Doe\n";
+
+    private String commandWord;
+
+    public EditCommandMacroParser(String commandWord) {
+        this.commandWord = commandWord;
+    }
+
+    /**
+     * Parses the given {@code String} of arguments in the context of the EditCommand
+     */
+    public EditCommand parse(String args) throws ParseException {
+        requireNonNull(args);
+        String trimmedArgs = args.trim();
+        if (trimmedArgs.isEmpty()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, MACRO_MESSAGE_USAGE));
+        }
+        Index index;
+
+        try {
+            index = ParserUtil.parseIndex(trimmedArgs.split("\\s+")[0]);
+        } catch (ParseException pe) {
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, MACRO_MESSAGE_USAGE), pe);
+        }
+
+        String argString = trimmedArgs.split("\\s+", 2)[1];
+        EditPersonDescriptor editPersonDescriptor = new EditPersonDescriptor();
+        switch (commandWord) {
+        case "name":
+            editPersonDescriptor.setName(ParserUtil.parseName(argString));
+            break;
+        case "phone":
+            editPersonDescriptor.setPhone(ParserUtil.parsePhone(argString));
+            break;
+        case "email":
+            editPersonDescriptor.setEmail(ParserUtil.parseEmail(argString));
+            break;
+        case "address":
+            editPersonDescriptor.setAddress(ParserUtil.parseAddress(argString));
+            break;
+        case "lead":
+            editPersonDescriptor.setLead(ParserUtil.parseLead(argString));
+            break;
+        case "telegram":
+            editPersonDescriptor.setTelegram(ParserUtil.parseTelegram(argString));
+            break;
+        case "profession":
+            editPersonDescriptor.setProfession(ParserUtil.parseProfession(argString));
+            break;
+        case "income":
+            editPersonDescriptor.setIncome(ParserUtil.parseIncome(argString));
+            break;
+        case "details":
+            editPersonDescriptor.setDetails(ParserUtil.parseDetails(argString));
+            break;
+        default:
+            throw new ParseException(String.format(MESSAGE_INVALID_COMMAND_FORMAT, MACRO_MESSAGE_USAGE));
+        }
+        return new EditCommand(index, editPersonDescriptor);
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/EditCommandMacroParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/EditCommandMacroParserTest.java
@@ -1,0 +1,56 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.logic.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_PERSON;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.EditCommand;
+import seedu.address.logic.commands.EditCommand.EditPersonDescriptor;
+import seedu.address.model.person.lead.Lead;
+import seedu.address.model.person.lead.LeadType;
+
+public class EditCommandMacroParserTest {
+    private static final String MESSAGE_INVALID_FORMAT =
+        String.format(MESSAGE_INVALID_COMMAND_FORMAT, EditCommandMacroParser.MACRO_MESSAGE_USAGE);
+
+    private EditCommandMacroParser badCommandWordParser = new EditCommandMacroParser("edit");
+    private EditCommandMacroParser goodCommandWordParser = new EditCommandMacroParser("lead");
+
+    @Test
+    public void parse_validCommandWord_success() {
+        Index targetIndex = INDEX_FIRST_PERSON;
+        EditPersonDescriptor descriptor = new EditPersonDescriptor();
+        descriptor.setLead(new Lead(LeadType.HOT));
+        EditCommand expectedCommand = new EditCommand(targetIndex, descriptor);
+        String userInput = "1 HOT";
+
+        assertParseSuccess(goodCommandWordParser, userInput, expectedCommand);
+    }
+
+    @Test
+    public void parse_validCommandWordInvalidInput_failure() {
+        EditPersonDescriptor descriptor = new EditPersonDescriptor();
+        descriptor.setLead(new Lead(LeadType.HOT));
+        String userInput = "1 medium";
+
+        assertParseFailure(goodCommandWordParser, userInput, Lead.MESSAGE_CONSTRAINTS);
+    }
+
+    @Test
+    public void parse_invalidCommandWord_failure() {
+        String userInput = "1 HOT";
+
+        assertParseFailure(badCommandWordParser, userInput, MESSAGE_INVALID_FORMAT);
+    }
+
+    @Test
+    public void parse_invalidCommandWordInvalidInput_failure() {
+        String userInput = "1 medium";
+
+        assertParseFailure(badCommandWordParser, userInput, MESSAGE_INVALID_FORMAT);
+    }
+}


### PR DESCRIPTION
Will close #47 
Users can now enter "lead 1 HOT" to just change the lead of the first indexed person to HOT.
This will also work with other fields in person (except Tag) and is really just a macro for "edit l/HOT"


TODO:

- [x] Add Documentation for this (and also document that it doesn't work for Tag and Interactions)
- [x] Add test cases