### PR TITLE
Fix display error when `Person` has no `lead`

### DIFF
--- a/src/main/java/seedu/address/logic/commands/CreateCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CreateCommand.java
@@ -70,10 +70,6 @@ public class CreateCommand extends Command {
         }
 
         model.addPerson(toAdd);
-
-        // move focus to the newly created person
-        model.setSelectedPerson(toAdd);
-
         return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(toAdd)));
     }
 

--- a/src/main/java/seedu/address/logic/commands/CreateCommand.java
+++ b/src/main/java/seedu/address/logic/commands/CreateCommand.java
@@ -70,6 +70,10 @@ public class CreateCommand extends Command {
         }
 
         model.addPerson(toAdd);
+
+        // move focus to the newly created person
+        model.setSelectedPerson(toAdd);
+
         return new CommandResult(String.format(MESSAGE_SUCCESS, Messages.format(toAdd)));
     }
 

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -103,9 +103,6 @@ public class EditCommand extends Command {
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         model.getReminderList().setReminderListDirty();
 
-        // move focus to the edited person
-        model.setSelectedPerson(editedPerson);
-
         return new CommandResult(String.format(MESSAGE_EDIT_PERSON_SUCCESS, Messages.format(editedPerson)));
     }
 

--- a/src/main/java/seedu/address/logic/commands/InteractionCommand.java
+++ b/src/main/java/seedu/address/logic/commands/InteractionCommand.java
@@ -65,9 +65,6 @@ public class InteractionCommand extends Command {
         model.updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
         model.getReminderList().setReminderListDirty();
 
-        // move focus to the edited person
-        model.setSelectedPerson(editedPerson);
-
         return new CommandResult(String.format(MESSAGE_INTERACTION_SUCCESS, editedPerson));
     }
 

--- a/src/main/java/seedu/address/model/ModelManager.java
+++ b/src/main/java/seedu/address/model/ModelManager.java
@@ -115,6 +115,7 @@ public class ModelManager implements Model {
     @Override
     public void addPerson(Person person) {
         addressBook.addPerson(person);
+        setSelectedPerson(person);
         updateFilteredPersonList(PREDICATE_SHOW_ALL_PERSONS);
     }
 
@@ -123,6 +124,7 @@ public class ModelManager implements Model {
         requireAllNonNull(target, editedPerson);
 
         addressBook.setPerson(target, editedPerson);
+        setSelectedPerson(editedPerson);
     }
 
     //=========== Dashboard ================================

--- a/src/main/java/seedu/address/model/person/Person.java
+++ b/src/main/java/seedu/address/model/person/Person.java
@@ -154,21 +154,21 @@ public class Person {
      * Returns true if the person is a hot lead.
      */
     public boolean isHotLead() {
-        return this.lead.isHot();
+        return this.lead != null && this.lead.isHot();
     }
 
     /**
      * Returns true if the person is a warm lead.
      */
     public boolean isWarmLead() {
-        return this.lead.isWarm();
+        return this.lead != null && this.lead.isWarm();
     }
 
     /**
      * Returns true if the person is a cold lead.
      */
     public boolean isColdLead() {
-        return this.lead.isCold();
+        return this.lead != null && this.lead.isCold();
     }
 
     /**

--- a/src/main/java/seedu/address/ui/ClientProfilePanel.java
+++ b/src/main/java/seedu/address/ui/ClientProfilePanel.java
@@ -16,6 +16,7 @@ import seedu.address.model.person.Person;
 import seedu.address.model.person.Profession;
 import seedu.address.model.person.TelegramHandle;
 import seedu.address.model.person.interaction.Interaction;
+import seedu.address.model.person.lead.Lead;
 
 /**
  * A UI component that displays the profile of a {@code Client}.
@@ -58,17 +59,21 @@ public class ClientProfilePanel extends UiPart<Region> {
         phone.setText(client.getPhone().value);
         address.setText(client.getAddress().value);
         email.setText(client.getEmail().value);
-        client.getTags().stream()
+        client.getTags()
+                .stream()
                 .sorted(Comparator.comparing(tag -> tag.tagName))
                 .forEach(tag -> tags.getChildren().add(new Label(tag.tagName)));
 
-        lead.setText(client.getLead().toString());
-        if (client.isHotLead()) {
-            lead.getStyleClass().add("hot-lead");
-        } else if (client.isWarmLead()) {
-            lead.getStyleClass().add("warm-lead");
-        } else if (client.isColdLead()) {
-            lead.getStyleClass().add("cold-lead");
+        Lead clientLead = client.getLead();
+        if (clientLead != null) {
+            lead.setText(client.getLead().toString());
+            if (client.isHotLead()) {
+                lead.getStyleClass().add("hot-lead");
+            } else if (client.isWarmLead()) {
+                lead.getStyleClass().add("warm-lead");
+            } else if (client.isColdLead()) {
+                lead.getStyleClass().add("cold-lead");
+            }
         }
 
         // optional fields


### PR DESCRIPTION
Fixes #136.

This is a bug in the `Lead` status getters in `Person`. There was no `null` check before checking the `LeadType`. So errors will be thrown the UI components displaying `Lead`s.