### PR TITLE
Use integers for income

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -282,6 +282,17 @@ delete 1
 
 --------------------------------------------------------------------------------------------------------------------
 
+# Miscellaneous Notes
+
+## `INCOME` Parameter
+
+Incomes must only consist of numerical inputs. Connectify does not yet support:
+- Decimal values `600.50`
+- Currencies `10000 USD`
+- Other non-numeric input e.g. `10,000`
+
+--------------------------------------------------------------------------------------------------------------------
+
 # FAQ [coming soon]
 
 

--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -172,9 +172,9 @@ public class ParserUtil {
             throw new ParseException(Income.MESSAGE_CONSTRAINTS);
         }
 
-        Double incomeDouble = Double.parseDouble(trimmedIncome);
+        Integer incomeInteger = Integer.parseInt(trimmedIncome);
 
-        return new Income(incomeDouble);
+        return new Income(incomeInteger);
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/Income.java
+++ b/src/main/java/seedu/address/model/person/Income.java
@@ -5,17 +5,17 @@ package seedu.address.model.person;
  */
 public class Income {
 
-    public static final String MESSAGE_CONSTRAINTS = "Income should only contain numbers "
+    public static final String MESSAGE_CONSTRAINTS = "Income should only contain integers "
             + "and it should not be blank";
 
-    public final Number value;
+    public final Integer value;
 
     /**
     * Constructs a {@code Income}.
     *
     * @param income A valid income.
     */
-    public Income(Number income) {
+    public Income(Integer income) {
         value = income;
     }
 
@@ -24,7 +24,7 @@ public class Income {
     */
     public static boolean isValidIncome(String test) {
         try {
-            Double.parseDouble(test);
+            Integer.parseInt(test);
             return true;
         } catch (NumberFormatException e) {
             return false;

--- a/src/main/java/seedu/address/model/person/Income.java
+++ b/src/main/java/seedu/address/model/person/Income.java
@@ -5,8 +5,8 @@ package seedu.address.model.person;
  */
 public class Income {
 
-    public static final String MESSAGE_CONSTRAINTS
-            = "Income should only contain positive integers less than 2147483648 and it should not be blank";
+    public static final String MESSAGE_CONSTRAINTS =
+            "Income should only contain positive integers less than 2147483648 and it should not be blank";
 
     public final Integer value;
 

--- a/src/main/java/seedu/address/model/person/Income.java
+++ b/src/main/java/seedu/address/model/person/Income.java
@@ -5,8 +5,8 @@ package seedu.address.model.person;
  */
 public class Income {
 
-    public static final String MESSAGE_CONSTRAINTS = "Income should only contain integers "
-            + "and it should not be blank";
+    public static final String MESSAGE_CONSTRAINTS
+            = "Income should only contain positive integers less than 2147483648 and it should not be blank";
 
     public final Integer value;
 
@@ -24,9 +24,10 @@ public class Income {
     */
     public static boolean isValidIncome(String test) {
         try {
-            Integer.parseInt(test);
-            return true;
+            int income = Integer.parseInt(test);
+            return income >= 0;
         } catch (NumberFormatException e) {
+            // If integer is too big, the exception will be thrown
             return false;
         }
     }

--- a/src/test/java/seedu/address/model/person/IncomeTest.java
+++ b/src/test/java/seedu/address/model/person/IncomeTest.java
@@ -2,7 +2,6 @@ package seedu.address.model.person;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
-import static seedu.address.testutil.Assert.assertThrows;
 
 import org.junit.jupiter.api.Test;
 

--- a/src/test/java/seedu/address/model/person/IncomeTest.java
+++ b/src/test/java/seedu/address/model/person/IncomeTest.java
@@ -1,0 +1,39 @@
+package seedu.address.model.person;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.testutil.Assert.assertThrows;
+
+import org.junit.jupiter.api.Test;
+
+public class IncomeTest {
+
+    // EP: valid income (integers)
+    @Test
+    public void isValidIncome_validIncome_returnsTrue() {
+        assertTrue(Income.isValidIncome("60000"));
+        assertTrue(Income.isValidIncome("100"));
+    }
+
+    // EP: null input
+    @Test
+    public void isValidIncome_nullInput_returnsFalse() {
+        assertFalse(Income.isValidIncome(null));
+    }
+
+    // EP: empty string
+    @Test
+    public void isValidIncome_emptyInput_returnsFalse() {
+        assertFalse(Income.isValidIncome(("")));
+        assertFalse(Income.isValidIncome((" ")));
+        assertFalse(Income.isValidIncome(("       ")));
+    }
+
+    // EP: invalid inputs (non-integers)
+    @Test
+    public void isValidIncome_invalidInput_returnsFalse() {
+        assertFalse(Income.isValidIncome(("100 USD")));
+        assertFalse(Income.isValidIncome(("123.50")));
+        assertFalse(Income.isValidIncome(("$60000")));
+    }
+}

--- a/src/test/java/seedu/address/model/person/IncomeTest.java
+++ b/src/test/java/seedu/address/model/person/IncomeTest.java
@@ -12,6 +12,9 @@ public class IncomeTest {
     public void isValidIncome_validIncome_returnsTrue() {
         assertTrue(Income.isValidIncome("60000"));
         assertTrue(Income.isValidIncome("100"));
+        assertTrue(Income.isValidIncome("0"));
+        assertTrue(Income.isValidIncome("1"));
+        assertTrue(Income.isValidIncome("2147483647"));
     }
 
     // EP: null input
@@ -34,5 +37,19 @@ public class IncomeTest {
         assertFalse(Income.isValidIncome(("100 USD")));
         assertFalse(Income.isValidIncome(("123.50")));
         assertFalse(Income.isValidIncome(("$60000")));
+    }
+
+    // EP: negative integers
+    @Test
+    public void isValidIncome_negativeInput_returnsFalse() {
+        assertFalse(Income.isValidIncome("-1"));
+        assertFalse(Income.isValidIncome("-8923"));
+    }
+
+    // EP: integers larger than MAX_INT
+    @Test
+    public void isValidIncome_largeInput_returnsFalse() {
+        assertFalse(Income.isValidIncome("2147483648"));
+        assertFalse(Income.isValidIncome("100000000000000"));
     }
 }


### PR DESCRIPTION
Fixes #168.
Fixes #159 (tried and verified).

### Changes
- Modified `Income` to only accept integers.
- Added test cases for `Income.isValidIncome`.
- Updated user guide under miscellaneous notes to reflect that the income parameter only accepts integers.