### PR TITLE
User guide: fix example formatting for creating a client

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -114,8 +114,8 @@ create n/NAME p/PHONE e/EMAIL a/ADDRESS [t/TAG]... [tg/TELEGRAM]
 
 **Example**
 ```text
-create n/Bernice Yu p/99272758 e/berniceyu@example.com
-a/Blk 30 Lorong 3 Serangoon Gardens, #07-18 t/colleagues
+create n/Bernice Yu p/99272758 e/berniceyu@example.com 
+a/Blk 30 Lorong 3 Serangoon Gardens, #07-18 t/colleagues 
 t/friends tg/@yuyubern pf/Graphic Designer i/60000
 ```
 


### PR DESCRIPTION
Fixes #152, fixes #154, fixes #146.

Added white space for multi-line example commands so that the formatting is correct when copied over to the command box of the application.