### PR TITLE
Add: Outcomes can be keyed in small case & tests

### DIFF
--- a/src/main/java/seedu/address/logic/parser/ParserUtil.java
+++ b/src/main/java/seedu/address/logic/parser/ParserUtil.java
@@ -203,7 +203,7 @@ public class ParserUtil {
         if (!Outcome.isValidOutcome(trimmedOutcome)) {
             throw new ParseException(Outcome.MESSAGE_CONSTRAINTS);
         }
-        return Outcome.valueOf(trimmedOutcome);
+        return Outcome.valueOf(trimmedOutcome.toUpperCase());
     }
 
     /**

--- a/src/main/java/seedu/address/model/person/interaction/Interaction.java
+++ b/src/main/java/seedu/address/model/person/interaction/Interaction.java
@@ -26,7 +26,7 @@ public class Interaction {
         * Returns true if a given string is a valid outcome.
         */
         public static boolean isValidOutcome(String test) {
-            return test.matches("CLOSED|INTERESTED|NOT_INTERESTED|FOLLOWUP_REQUIRED|UNKNOWN");
+            return test.toUpperCase().matches("CLOSED|INTERESTED|NOT_INTERESTED|FOLLOWUP_REQUIRED|UNKNOWN");
         }
     }
 

--- a/src/test/java/seedu/address/logic/parser/InteractionCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/InteractionCommandParserTest.java
@@ -42,6 +42,16 @@ public class InteractionCommandParserTest {
         assertParseFailure(parser,
                 CliSyntax.PREFIX_OUTCOME + "INTERESTED note about interaction",
                 expectedMessage);
+
+        // no arguments at all
+        assertParseFailure(parser,
+                "",
+                String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, InteractionCommand.MESSAGE_USAGE));
+
+        // no outcome and no note
+        assertParseFailure(parser,
+                "1",
+                String.format(Messages.MESSAGE_INVALID_COMMAND_FORMAT, InteractionCommand.MESSAGE_USAGE));
     }
 
     @Test
@@ -55,5 +65,26 @@ public class InteractionCommandParserTest {
         assertParseFailure(parser,
                 "1 " + CliSyntax.PREFIX_OUTCOME + "notAnOutcome note about interaction",
                 Interaction.Outcome.MESSAGE_CONSTRAINTS);
+    }
+
+    @Test
+    public void parse_uncapitalisedOutcome_success() {
+        // Interaction interaction = new Interaction("note about interaction", Interaction.Outcome.INTERESTED);
+        // InteractionCommand expectedCommand = new InteractionCommand(targetIndex, interaction);
+        // assertParseSuccess(parser, userInput, expectedCommand);
+
+
+        Index targetIndex = Index.fromOneBased(1);
+        String userInput = targetIndex.getOneBased()
+                + " " + CliSyntax.PREFIX_OUTCOME + "interested note about interaction in small case";
+        Interaction interaction =
+            new Interaction("note about interaction in small case", Interaction.Outcome.INTERESTED);
+        InteractionCommand expectedCommand = new InteractionCommand(targetIndex, interaction);
+        assertParseSuccess(parser, userInput, expectedCommand);
+
+        String userInput2 = targetIndex.getOneBased()
+                + " " + CliSyntax.PREFIX_OUTCOME + "iNtErESTeD note about interaction in small case";
+        assertParseSuccess(parser, userInput2, expectedCommand);
+
     }
 }


### PR DESCRIPTION
Changes:
Added functionality such that interaction outcomes can now be keyed in small case.
This will fix #164
